### PR TITLE
remove ambiguous flag: tera_master_addr and tera_tabletnode_addr

### DIFF
--- a/src/master/master_entry.cc
+++ b/src/master/master_entry.cc
@@ -12,7 +12,6 @@
 #include "master/remote_master.h"
 #include "utils/utils_cmd.h"
 
-DECLARE_string(tera_master_addr);
 DECLARE_string(tera_master_port);
 
 namespace tera {
@@ -27,8 +26,7 @@ MasterEntry::~MasterEntry() {}
 
 bool MasterEntry::StartServer() {
     IpAddress master_addr(utils::GetLocalHostAddr(), FLAGS_tera_master_port);
-    FLAGS_tera_master_addr = master_addr.ToString();
-    LOG(INFO) << "Start master RPC server at: " << FLAGS_tera_master_addr;
+    LOG(INFO) << "Start master RPC server at: " << master_addr.ToString();
 
     m_master_impl.reset(new MasterImpl());
     m_remote_master = new RemoteMaster(m_master_impl.get());
@@ -38,7 +36,7 @@ bool MasterEntry::StartServer() {
     }
 
     m_rpc_server.RegisterService(m_remote_master);
-    if (!m_rpc_server.Start(FLAGS_tera_master_addr)) {
+    if (!m_rpc_server.Start(master_addr.ToString())) {
         LOG(ERROR) << "start RPC server error";
         return false;
     }

--- a/src/proto/master_client.cc
+++ b/src/proto/master_client.cc
@@ -9,7 +9,6 @@
 #include "proto/master_client.h"
 
 
-DECLARE_string(tera_master_addr);
 DECLARE_string(tera_master_port);
 DECLARE_int32(tera_master_connect_retry_times);
 DECLARE_int32(tera_master_connect_retry_period);
@@ -19,8 +18,7 @@ namespace tera {
 namespace master {
 
 MasterClient::MasterClient()
-    : RpcClient<MasterServer::Stub>(FLAGS_tera_master_addr + ":" + FLAGS_tera_master_port,
-                                    FLAGS_tera_master_connect_retry_period,
+    : RpcClient<MasterServer::Stub>("", FLAGS_tera_master_connect_retry_period,
                                     FLAGS_tera_master_connect_timeout_period,
                                     FLAGS_tera_master_connect_retry_times) {}
 

--- a/src/proto/tabletnode_client.cc
+++ b/src/proto/tabletnode_client.cc
@@ -8,7 +8,6 @@
 
 #include "proto/tabletnode_client.h"
 
-DECLARE_string(tera_tabletnode_addr);
 DECLARE_string(tera_tabletnode_port);
 DECLARE_int32(tera_tabletnode_connect_retry_times);
 DECLARE_int32(tera_tabletnode_connect_retry_period);
@@ -20,16 +19,14 @@ namespace tabletnode {
 
 TabletNodeClient::TabletNodeClient()
     : RpcClient<TabletNodeServer::Stub>(
-                FLAGS_tera_tabletnode_addr + ":" + FLAGS_tera_tabletnode_port,
-                FLAGS_tera_tabletnode_connect_retry_period,
+                "", FLAGS_tera_tabletnode_connect_retry_period,
                 FLAGS_tera_tabletnode_connect_timeout_period,
                 FLAGS_tera_tabletnode_connect_retry_times) {}
 
 TabletNodeClient::TabletNodeClient(int32_t wait_time, int32_t rpc_timeout,
                                    int32_t retry_times)
     : RpcClient<TabletNodeServer::Stub>(
-            FLAGS_tera_tabletnode_addr + ":" + FLAGS_tera_tabletnode_port,
-            wait_time, rpc_timeout, retry_times) {}
+            "", wait_time, rpc_timeout, retry_times) {}
 
 
 TabletNodeClient::~TabletNodeClient() {}

--- a/src/tabletnode/tabletnode_entry.cc
+++ b/src/tabletnode/tabletnode_entry.cc
@@ -24,7 +24,6 @@
 #include "utils/timer.h"
 #include "utils/utils_cmd.h"
 
-DECLARE_string(tera_tabletnode_addr);
 DECLARE_string(tera_tabletnode_port);
 DECLARE_int64(tera_heartbeat_period);
 DECLARE_int32(tera_garbage_collect_period);
@@ -50,8 +49,7 @@ bool TabletNodeEntry::StartServer() {
     SetProcessorAffinity();
 
     IpAddress tabletnode_addr(utils::GetLocalHostAddr(), FLAGS_tera_tabletnode_port);
-    FLAGS_tera_tabletnode_addr = tabletnode_addr.GetIp();
-    LOG(INFO) << "Start RPC server at: " << FLAGS_tera_tabletnode_addr;
+    LOG(INFO) << "Start RPC server at: " << tabletnode_addr.ToString();
 
     TabletNodeInfo tabletnode_info;
     tabletnode_info.set_addr(tabletnode_addr.ToString());
@@ -67,7 +65,7 @@ bool TabletNodeEntry::StartServer() {
 
     // 注册给rpcserver, rpcserver会负责delete
     m_rpc_server.RegisterService(m_remote_tabletnode);
-    if (!m_rpc_server.Start(FLAGS_tera_tabletnode_addr)) {
+    if (!m_rpc_server.Start(tabletnode_addr.ToString())) {
         LOG(ERROR) << "start RPC server error";
         return false;
     }

--- a/src/tera_flags.cc
+++ b/src/tera_flags.cc
@@ -59,7 +59,6 @@ DEFINE_int64(tera_io_scan_stream_task_pending_time, 180, "the max pending time (
 
 /////////  master /////////
 
-DEFINE_string(tera_master_addr, "127.0.0.1", "the master address of tera system");
 DEFINE_string(tera_master_port, "10000", "the master port of tera system");
 DEFINE_int64(tera_heartbeat_timeout_period_factor, 120, "the timeout period factor when lose heartbeat");
 DEFINE_int32(tera_master_connect_retry_times, 5, "the max retry times when connect to master");
@@ -133,7 +132,6 @@ DEFINE_int32(tera_master_gc_period, 60000, "the period (in ms) for master gc");
 
 ///////// tablet node  /////////
 
-DEFINE_string(tera_tabletnode_addr, "127.0.0.1", "the tablet node address of tera system");
 DEFINE_string(tera_tabletnode_port, "20000", "the tablet node port of tera system");
 DEFINE_int32(tera_tabletnode_write_thread_num, 10, "the write thread number of tablet node server");
 DEFINE_int32(tera_tabletnode_read_thread_num, 40, "the read thread number of tablet node server");


### PR DESCRIPTION
1. Somewhere "addr" means "ip:port", and somewhere else it means "ip". We set that addr is ip:port from now on.
2. local ip is fetched through local api; it should not be a FLAG