### PR TITLE
load/unload/merge/split concurrency control

### DIFF
--- a/depends.mk
+++ b/depends.mk
@@ -5,14 +5,14 @@
 #       automatically config this for you.
 ################################################################
 
-SOFA_PBRPC_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
-PROTOBUF_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
-SNAPPY_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
-ZOOKEEPER_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
-GFLAGS_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
-GLOG_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
-GPERFTOOLS_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
-BOOST_INCDIR=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
+SOFA_PBRPC_PREFIX=
+PROTOBUF_PREFIX=
+SNAPPY_PREFIX=
+ZOOKEEPER_PREFIX=
+GFLAGS_PREFIX=
+GLOG_PREFIX=
+GPERFTOOLS_PREFIX=
+BOOST_INCDIR=
 
 SOFA_PBRPC_INCDIR = $(SOFA_PBRPC_PREFIX)/include
 PROTOBUF_INCDIR = $(PROTOBUF_PREFIX)/include

--- a/depends.mk
+++ b/depends.mk
@@ -5,14 +5,14 @@
 #       automatically config this for you.
 ################################################################
 
-SOFA_PBRPC_PREFIX=
-PROTOBUF_PREFIX=
-SNAPPY_PREFIX=
-ZOOKEEPER_PREFIX=
-GFLAGS_PREFIX=
-GLOG_PREFIX=
-GPERFTOOLS_PREFIX=
-BOOST_INCDIR=
+SOFA_PBRPC_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
+PROTOBUF_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
+SNAPPY_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
+ZOOKEEPER_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
+GFLAGS_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
+GLOG_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
+GPERFTOOLS_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
+BOOST_INCDIR=$(HOME)/jx-tera-github/tera/thirdparty
 
 SOFA_PBRPC_INCDIR = $(SOFA_PBRPC_PREFIX)/include
 PROTOBUF_INCDIR = $(PROTOBUF_PREFIX)/include

--- a/depends.mk
+++ b/depends.mk
@@ -5,14 +5,14 @@
 #       automatically config this for you.
 ################################################################
 
-SOFA_PBRPC_PREFIX=
-PROTOBUF_PREFIX=
-SNAPPY_PREFIX=
-ZOOKEEPER_PREFIX=
-GFLAGS_PREFIX=
-GLOG_PREFIX=
-GPERFTOOLS_PREFIX=
-BOOST_INCDIR=
+SOFA_PBRPC_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
+PROTOBUF_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
+SNAPPY_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
+ZOOKEEPER_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
+GFLAGS_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
+GLOG_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
+GPERFTOOLS_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
+BOOST_INCDIR=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
 
 SOFA_PBRPC_INCDIR = $(SOFA_PBRPC_PREFIX)/include
 PROTOBUF_INCDIR = $(PROTOBUF_PREFIX)/include

--- a/depends.mk
+++ b/depends.mk
@@ -5,14 +5,14 @@
 #       automatically config this for you.
 ################################################################
 
-SOFA_PBRPC_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
-PROTOBUF_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
-SNAPPY_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
-ZOOKEEPER_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
-GFLAGS_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
-GLOG_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
-GPERFTOOLS_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
-BOOST_INCDIR=$(HOME)/jx-tera-github/tera/thirdparty
+SOFA_PBRPC_PREFIX=
+PROTOBUF_PREFIX=
+SNAPPY_PREFIX=
+ZOOKEEPER_PREFIX=
+GFLAGS_PREFIX=
+GLOG_PREFIX=
+GPERFTOOLS_PREFIX=
+BOOST_INCDIR=
 
 SOFA_PBRPC_INCDIR = $(SOFA_PBRPC_PREFIX)/include
 PROTOBUF_INCDIR = $(PROTOBUF_PREFIX)/include

--- a/src/master/master_impl.cc
+++ b/src/master/master_impl.cc
@@ -1223,22 +1223,6 @@ void MasterImpl::LoadBalance() {
 
     m_load_balance_timer_id = kInvalidTimerId;
     EnableLoadBalanceTimer();
-
-    /* (jinxiao)
-    // try unload
-    std::vector<TabletNodePtr>::iterator node_it = all_node_list.begin();
-    for (; node_it != all_node_list.end(); ++node_it) {
-        TabletPtr next_tablet;
-        LOG(INFO) << "[LoadBalance] enter UnloadNextWaitTablet";
-        while ((*node_it)->UnloadNextWaitTablet(&next_tablet)) {
-            UnloadClosure* done =
-                NewClosure(this, &MasterImpl::UnloadTabletCallback, next_tablet,
-                           FLAGS_tera_master_impl_retry_times);
-            UnloadTabletAsync(next_tablet, done);
-        }
-        LOG(INFO) << "[LoadBalance] leave UnloadNextWaitTablet";
-    }  
-    */
 }
 
 void MasterImpl::TabletNodeLoadBalance(const std::string& tabletnode_addr,
@@ -3173,8 +3157,6 @@ void MasterImpl::MergeTabletAsync(TabletPtr tablet_p1, TabletPtr tablet_p2, Mute
             NewClosure(this, &MasterImpl::MergeTabletUnloadCallback, tablet_p2, tablet_p1, mu);
         TryUnload4MergeTablet(tablet_p1, done1);
         TryUnload4MergeTablet(tablet_p2, done2);
-        //UnloadTabletAsync(tablet_p1, done1);
-        //UnloadTabletAsync(tablet_p2, done2);
     } else {
         LOG(WARNING) << "[merge] tablet not ready, merge failed and rollback.";
         tablet_p1->SetStatusIf(kTableReady, kTableUnLoading);

--- a/src/master/master_impl.h
+++ b/src/master/master_impl.h
@@ -126,7 +126,6 @@ public:
     void DisableQueryTabletNodeTimer();
 
     bool GetMetaTabletAddr(std::string* addr);
-    void TryLoadTablet(TabletPtr tablet, std::string addr = "");
 
 private:
     typedef Closure<void, SnapshotRequest*, SnapshotResponse*, bool, int> SnapshotClosure;
@@ -198,7 +197,9 @@ private:
 
     void RetryLoadTablet(TabletPtr tablet, int32_t retry_times);
     void RetryUnloadTablet(TabletPtr tablet, int32_t retry_times);
+    void TryLoadTablet(TabletPtr tablet, std::string addr = "");
     bool TrySplitTablet(TabletPtr tablet);
+    void TryUnloadTablet(TabletPtr tablet, UnloadClosure* done);
     bool TryMergeTablet(TabletPtr tablet);
     void TryMoveTablet(TabletPtr tablet, const std::string& server_addr = "");
 

--- a/src/master/master_impl.h
+++ b/src/master/master_impl.h
@@ -200,6 +200,7 @@ private:
     void TryLoadTablet(TabletPtr tablet, std::string addr = "");
     bool TrySplitTablet(TabletPtr tablet);
     void TryUnloadTablet(TabletPtr tablet, UnloadClosure* done);
+    void TryUnload4MergeTablet(TabletPtr tablet, UnloadClosure* done);
     bool TryMergeTablet(TabletPtr tablet);
     void TryMoveTablet(TabletPtr tablet, const std::string& server_addr = "");
 
@@ -299,7 +300,7 @@ private:
                              SplitTabletResponse* response, bool failed,
                              int error_code);
 
-    void MergeTabletAsync(TabletPtr tablet_p1, TabletPtr tablet_p2);
+    void MergeTabletAsync(TabletPtr tablet_p1, TabletPtr tablet_p2, Mutex *mu);
     void MergeTabletAsyncPhase2(TabletPtr tablet_p1, TabletPtr tablet_p2);
     void MergeTabletUnloadCallback(TabletPtr tablet, TabletPtr tablet2, Mutex* mutex,
                                            UnloadTabletRequest* request,
@@ -491,6 +492,9 @@ private:
     std::set<std::string> m_gc_tabletnodes;
     int64_t m_gc_timer_id;
     bool m_gc_query_enable;
+
+    std::map<TabletPtr, TabletPtr> m_unload4merge_pair;
+    std::map<std::pair<TabletPtr, TabletPtr>, Mutex*> m_unload4merge_mutex;
 };
 
 } // namespace master

--- a/src/master/tabletnode_manager.cc
+++ b/src/master/tabletnode_manager.cc
@@ -30,9 +30,8 @@ Spatula::Spatula() :
 
 Spatula::~Spatula() {
     if (!m_wait_list.empty()) {
-        LOG(INFO) << "~spatula";
         Print();
-        LOG(FATAL) << "fatal";
+        LOG(FATAL) << "destruct a non empty spatula!";
     }
 }
 
@@ -86,16 +85,14 @@ uint32_t Spatula::PushCount() {
 
 TabletNode::TabletNode() : m_state(kOffLine),
     m_report_status(kTabletNodeInit), m_data_size(0), m_load(0),
-    m_update_time(0), m_query_fail_count(0), m_plan_move_in_count(0),
-    m_load_spatula(), m_unload_spatula(), m_unload4merge_spatula(), m_split_spatula() {
+    m_update_time(0), m_query_fail_count(0), m_plan_move_in_count(0) {
     m_info.set_addr("");
 }
 
 TabletNode::TabletNode(const std::string& addr, const std::string& uuid)
     : m_addr(addr), m_uuid(uuid), m_state(kOffLine),
       m_report_status(kTabletNodeInit), m_data_size(0), m_load(0),
-      m_update_time(0), m_query_fail_count(0), m_plan_move_in_count(0),
-      m_load_spatula(), m_unload_spatula(), m_unload4merge_spatula(), m_split_spatula() {
+      m_update_time(0), m_query_fail_count(0), m_plan_move_in_count(0) {
     m_info.set_addr(addr);
 }
 

--- a/src/master/tabletnode_manager.cc
+++ b/src/master/tabletnode_manager.cc
@@ -11,6 +11,7 @@
 DECLARE_string(tera_master_meta_table_name);
 DECLARE_int32(tera_master_max_load_concurrency);
 DECLARE_int32(tera_master_max_split_concurrency);
+DECLARE_int32(tera_master_max_unload_concurrency);
 DECLARE_int32(tera_master_load_interval);
 DECLARE_double(tera_master_load_balance_size_overload_ratio);
 DECLARE_bool(tera_master_meta_isolate_enabled);
@@ -18,22 +19,92 @@ DECLARE_bool(tera_master_meta_isolate_enabled);
 namespace tera {
 namespace master {
 
+class Spatula;
+
+Spatula::Spatula() : 
+    m_doing_count(0),
+    m_wait_list(),
+    m_pop_count(0),
+    m_push_count(0) {
+}
+
+Spatula::~Spatula() {
+    if (!m_wait_list.empty()) {
+        LOG(INFO) << "~spatula"
+            << ", the pop-count:" << m_pop_count
+            << ", the push-count:" << m_push_count;
+        Print();
+        LOG(FATAL) << "fatal";
+    }
+}
+
+bool Spatula::IsWaitListEmpty() {
+    return m_wait_list.empty();
+}
+
+void Spatula::Push(TabletPtr tablet) {
+    m_wait_list.push_back(tablet);
+    m_push_count++;
+}
+
+TabletPtr Spatula::Pop() {
+    TabletPtr t = m_wait_list.front();
+    m_wait_list.pop_front();
+    m_pop_count++;
+    return t;
+}
+
+uint32_t Spatula::GetDoingCount() const {
+    return m_doing_count;
+}
+
+void Spatula::DoingCountPlusOne(){
+    m_doing_count++;
+}
+
+void Spatula::DoingCountMinusOne() {
+    CHECK(m_doing_count > 0) << "pop-count: " << m_pop_count
+        << "push-count: " << m_push_count;
+    m_doing_count--;
+}
+
+// print all item in wait list, for debug
+void Spatula::Print() {
+    LOG(INFO) << "[spatula] print start..." << m_wait_list.size();
+    for (std::list<TabletPtr>::iterator it = m_wait_list.begin();
+         it != m_wait_list.end(); ++it) {
+            LOG(INFO) << (*it)->GetPath();
+    }
+    LOG(INFO) << "[spatula] print done, doing count: " << m_doing_count;
+}
+
+uint32_t Spatula::PopCount() {
+    return m_pop_count;
+}
+
+uint32_t Spatula::PushCount() {
+    return m_push_count;
+}
+
 TabletNode::TabletNode() : m_state(kOffLine),
     m_report_status(kTabletNodeInit), m_data_size(0), m_load(0),
-    m_update_time(0), m_query_fail_count(0), m_onload_count(0),
-    m_onsplit_count(0), m_plan_move_in_count(0) {
+    m_update_time(0), m_query_fail_count(0), m_plan_move_in_count(0),
+    m_load_spatula(), m_unload_spatula(), m_split_spatula() {
     m_info.set_addr("");
 }
 
 TabletNode::TabletNode(const std::string& addr, const std::string& uuid)
     : m_addr(addr), m_uuid(uuid), m_state(kOffLine),
       m_report_status(kTabletNodeInit), m_data_size(0), m_load(0),
-      m_update_time(0), m_query_fail_count(0), m_onload_count(0),
-      m_onsplit_count(0), m_plan_move_in_count(0) {
+      m_update_time(0), m_query_fail_count(0), m_plan_move_in_count(0),
+      m_load_spatula(), m_unload_spatula(), m_split_spatula() {
     m_info.set_addr(addr);
 }
 
-TabletNode::~TabletNode() {}
+TabletNode::~TabletNode() {
+    LOG(INFO) << "dests" << " addr: " << m_addr;
+    m_unload_spatula.Print();
+}
 
 TabletNodeInfo TabletNode::GetInfo() {
     MutexLock lock(&m_mutex);
@@ -98,6 +169,21 @@ bool TabletNode::MayLoadNow() {
     return false;
 }
 
+bool TabletNode::TryUnload(TabletPtr tablet) {
+    MutexLock lock(&m_mutex);
+    if (m_unload_spatula.IsWaitListEmpty()
+        && m_unload_spatula.GetDoingCount() < static_cast<uint32_t>(FLAGS_tera_master_max_unload_concurrency)) {
+        m_unload_spatula.DoingCountPlusOne();
+        LOG(INFO) << "[unload] doing count:" << m_unload_spatula.GetDoingCount()
+                  << ", waitlist:" << (m_unload_spatula.IsWaitListEmpty() ? "empty":"not empty");
+        return true;
+    }
+    m_unload_spatula.Push(tablet);
+    LOG(INFO) << "[unload] Push done, the push-count: " << m_unload_spatula.PushCount();
+    m_unload_spatula.Print();
+    return false;
+}
+
 bool TabletNode::TryLoad(TabletPtr tablet) {
     MutexLock lock(&m_mutex);
     m_data_size += tablet->GetDataSize();
@@ -108,17 +194,17 @@ bool TabletNode::TryLoad(TabletPtr tablet) {
     }
     //VLOG(5) << "load on: " << m_addr << ", size: " << tablet->GetDataSize()
     //      << ", total size: " << m_data_size;
-    if (m_wait_load_list.empty()
-        && m_onload_count < static_cast<uint32_t>(FLAGS_tera_master_max_load_concurrency)) {
+    if (m_load_spatula.IsWaitListEmpty()
+        && m_load_spatula.GetDoingCount() < static_cast<uint32_t>(FLAGS_tera_master_max_load_concurrency)) {
         BeginLoad();
         return true;
     }
-    m_wait_load_list.push_back(tablet);
+    m_load_spatula.Push(tablet);
     return false;
 }
 
 void TabletNode::BeginLoad() {
-    ++m_onload_count;
+    m_load_spatula.DoingCountPlusOne();
     m_recent_load_time_list.push_back(get_micros());
     uint32_t list_size = m_recent_load_time_list.size();
     if (list_size > static_cast<uint32_t>(FLAGS_tera_master_max_load_concurrency)) {
@@ -127,24 +213,51 @@ void TabletNode::BeginLoad() {
     }
 }
 
+bool TabletNode::FinishUnload(TabletPtr tablet) {
+    MutexLock lock(&m_mutex);
+    m_unload_spatula.DoingCountMinusOne();
+    return true;
+}
+
+bool TabletNode::FinishSplit(TabletPtr tablet) {
+    MutexLock lock(&m_mutex);
+    m_split_spatula.DoingCountMinusOne();
+    return true;
+}
+
 bool TabletNode::FinishLoad(TabletPtr tablet) {
     MutexLock lock(&m_mutex);
-    assert(m_onload_count > 0);
-    --m_onload_count;
+    m_load_spatula.DoingCountMinusOne();
+    return true;
+}
+
+bool TabletNode::UnloadNextWaitTablet(TabletPtr* tablet) {
+    MutexLock lock(&m_mutex);
+    if (m_unload_spatula.GetDoingCount() 
+        >= static_cast<uint32_t>(FLAGS_tera_master_max_unload_concurrency)) {
+        LOG(INFO) << "[unload] up to top";
+        return false;
+    }
+    if (m_unload_spatula.IsWaitListEmpty()) {
+        LOG(INFO) << "[unload] wait list is empty";
+        return false;
+    }
+    *tablet = m_unload_spatula.Pop();
+    LOG(INFO) << "[unload] pop() : " << (*tablet)->GetPath() 
+        << ", the pop-count: " << m_unload_spatula.PopCount();
+    m_unload_spatula.DoingCountPlusOne();
     return true;
 }
 
 bool TabletNode::LoadNextWaitTablet(TabletPtr* tablet) {
     MutexLock lock(&m_mutex);
-    if (m_onload_count >= static_cast<uint32_t>(FLAGS_tera_master_max_load_concurrency)) {
+    if (m_load_spatula.GetDoingCount() >= static_cast<uint32_t>(FLAGS_tera_master_max_load_concurrency)) {
         return false;
     }
-    std::list<TabletPtr>::iterator it = m_wait_load_list.begin();
-    if (it == m_wait_load_list.end()) {
+    if (m_load_spatula.IsWaitListEmpty()) {
         return false;
     }
-    *tablet = *it;
-    m_wait_load_list.pop_front();
+    *tablet = m_load_spatula.Pop();
     BeginLoad();
     return true;
 }
@@ -154,33 +267,27 @@ bool TabletNode::TrySplit(TabletPtr tablet) {
     m_data_size -= tablet->GetDataSize();
 //    VLOG(5) << "split on: " << m_addr << ", size: " << tablet->GetDataSize()
 //        << ", total size: " << m_data_size;
-    if (m_wait_split_list.empty()
-        && m_onsplit_count < static_cast<uint32_t>(FLAGS_tera_master_max_split_concurrency)) {
-        ++m_onsplit_count;
+    if (m_split_spatula.IsWaitListEmpty()
+        && m_split_spatula.GetDoingCount() < static_cast<uint32_t>(FLAGS_tera_master_max_split_concurrency)) {
+        m_split_spatula.DoingCountPlusOne();
+        LOG(INFO) << "[new split] after plus : " << m_split_spatula.GetDoingCount();
         return true;
     }
-    m_wait_split_list.push_back(tablet);
+    m_split_spatula.Push(tablet);
     return false;
-}
-
-bool TabletNode::FinishSplit(TabletPtr tablet) {
-    MutexLock lock(&m_mutex);
-    --m_onsplit_count;
-    return true;
 }
 
 bool TabletNode::SplitNextWaitTablet(TabletPtr* tablet) {
     MutexLock lock(&m_mutex);
-    if (m_onsplit_count >= static_cast<uint32_t>(FLAGS_tera_master_max_split_concurrency)) {
+    if (m_split_spatula.GetDoingCount() 
+        >= static_cast<uint32_t>(FLAGS_tera_master_max_split_concurrency)) {
         return false;
     }
-    std::list<TabletPtr>::iterator it = m_wait_split_list.begin();
-    if (it == m_wait_split_list.end()) {
+    if (m_split_spatula.IsWaitListEmpty()) {
         return false;
     }
-    *tablet = *it;
-    m_wait_split_list.pop_front();
-    ++m_onsplit_count;
+    *tablet = m_split_spatula.Pop();
+    m_split_spatula.DoingCountPlusOne();
     return true;
 }
 
@@ -303,8 +410,8 @@ void TabletNodeManager::UpdateTabletNode(const std::string& addr,
     node->m_table_size = state.m_table_size;
 
     node->m_info.set_status_m(NodeStateToString(node->m_state));
-    node->m_info.set_tablet_onload(node->m_onload_count);
-    node->m_info.set_tablet_onsplit(node->m_onsplit_count);
+    node->m_info.set_tablet_onload(node->m_load_spatula.GetDoingCount());
+    node->m_info.set_tablet_onsplit(node->m_split_spatula.GetDoingCount());
     VLOG(15) << "update tabletnode : " << addr;
 }
 

--- a/src/master/tabletnode_manager.h
+++ b/src/master/tabletnode_manager.h
@@ -30,6 +30,28 @@ enum NodeState {
 
 std::string NodeStateToString(NodeState state);
 
+class Spatula {
+public:
+    Spatula();
+    ~Spatula();
+    bool IsWaitListEmpty();
+    void Push(TabletPtr tablet);
+    TabletPtr Spatula::Pop();
+    uint32_t Spatula::GetDoingCount() const;
+    void Spatula::DoingCountPlusOne();
+    void Spatula::DoingCountMinusOne();
+    // print all item in wait list, for debug
+    void Spatula::Print();
+    uint32_t PushCount();
+    uint32_t PopCount();
+
+private:
+    uint32_t m_doing_count;
+    std::list<TabletPtr> m_wait_list;
+    uint32_t m_pop_count;
+    uint32_t m_push_count;
+};
+
 struct TabletNode {
     mutable Mutex m_mutex;
     std::string m_addr;
@@ -45,11 +67,16 @@ struct TabletNode {
     std::map<std::string, uint64_t> m_table_size;
 
     uint32_t m_query_fail_count;
-    uint32_t m_onload_count;
-    uint32_t m_onsplit_count;
+    //uint32_t m_onload_count;
+    //uint32_t m_onsplit_count;
+    //uint32_t m_onunload_count;
     uint32_t m_plan_move_in_count;
-    std::list<TabletPtr> m_wait_load_list;
-    std::list<TabletPtr> m_wait_split_list;
+    //std::list<TabletPtr> m_wait_load_list;
+    //std::list<TabletPtr> m_wait_split_list;
+    //std::list<TabletPtr> m_wait_unload_list;
+    Spatula m_load_spatula;
+    Spatula m_unload_spatula;
+    Spatula m_split_spatula;
 
     // The start time of recent load operation.
     // Used to tell if node load too many tablets within short time.
@@ -81,6 +108,11 @@ struct TabletNode {
     bool TrySplit(TabletPtr tablet);
     bool FinishSplit(TabletPtr tablet);
     bool SplitNextWaitTablet(TabletPtr* tablet);
+
+    bool TryUnload(TabletPtr tablet);
+    void BeginUnload();
+    bool FinishUnload(TabletPtr tablet);
+    bool UnloadNextWaitTablet(TabletPtr* tablet);
 
     NodeState GetState();
     bool SetState(NodeState new_state, NodeState* old_state);

--- a/src/master/tabletnode_manager.h
+++ b/src/master/tabletnode_manager.h
@@ -76,6 +76,7 @@ struct TabletNode {
     //std::list<TabletPtr> m_wait_unload_list;
     Spatula m_load_spatula;
     Spatula m_unload_spatula;
+    Spatula m_unload4merge_spatula;
     Spatula m_split_spatula;
 
     // The start time of recent load operation.
@@ -113,6 +114,11 @@ struct TabletNode {
     void BeginUnload();
     bool FinishUnload(TabletPtr tablet);
     bool UnloadNextWaitTablet(TabletPtr* tablet);
+
+    bool TryUnload4Merge(TabletPtr tablet);
+    void BeginUnload4Merge();
+    bool FinishUnload4Merge(TabletPtr tablet);
+    bool TabletNode::Unload4MergeNextWaitTablet(TabletPtr* tablet);
 
     NodeState GetState();
     bool SetState(NodeState new_state, NodeState* old_state);

--- a/src/master/tabletnode_manager.h
+++ b/src/master/tabletnode_manager.h
@@ -36,12 +36,12 @@ public:
     ~Spatula();
     bool IsWaitListEmpty();
     void Push(TabletPtr tablet);
-    TabletPtr Spatula::Pop();
-    uint32_t Spatula::GetDoingCount() const;
-    void Spatula::DoingCountPlusOne();
-    void Spatula::DoingCountMinusOne();
+    TabletPtr Pop();
+    uint32_t GetDoingCount() const;
+    void DoingCountPlusOne();
+    void DoingCountMinusOne();
     // print all item in wait list, for debug
-    void Spatula::Print();
+    void Print();
     uint32_t PushCount();
     uint32_t PopCount();
 
@@ -118,7 +118,7 @@ struct TabletNode {
     bool TryUnload4Merge(TabletPtr tablet);
     void BeginUnload4Merge();
     bool FinishUnload4Merge(TabletPtr tablet);
-    bool TabletNode::Unload4MergeNextWaitTablet(TabletPtr* tablet);
+    bool Unload4MergeNextWaitTablet(TabletPtr* tablet);
 
     NodeState GetState();
     bool SetState(NodeState new_state, NodeState* old_state);

--- a/src/sdk/sdk_utils.cc
+++ b/src/sdk/sdk_utils.cc
@@ -480,15 +480,19 @@ bool SetTableProperties(const PropertyList& props, TableDescriptor* desc) {
                 return false;
             }
         } else if (prop.first == "splitsize") {
-            int splitsize = atoi(prop.second.c_str());
+            int64_t splitsize = atoi(prop.second.c_str());
             if (splitsize < 0) { // splitsize == 0 : split closed
                 LOG(ERROR) << "illegal value: " << prop.second
                     << " for property: " << prop.first;
                 return false;
             }
             desc->SetSplitSize(splitsize);
+            int64_t mergesize = desc->MergeSize();
+            if (mergesize > 0) {
+                desc->SetMergeSize(splitsize/5); // TODO (jinxiao) a better way?
+            }
         } else if (prop.first == "mergesize") {
-            int mergesize = atoi(prop.second.c_str());
+            int64_t mergesize = atoi(prop.second.c_str());
             if (mergesize < 0) { // mergesize == 0 : merge closed
                 LOG(ERROR) << "illegal value: " << prop.second
                     << " for property: " << prop.first;

--- a/src/tera_flags.cc
+++ b/src/tera_flags.cc
@@ -94,6 +94,7 @@ DEFINE_int64(tera_master_merge_timer_period, 180, "the actived time (in sec) for
 
 DEFINE_int32(tera_master_max_split_concurrency, 1, "the max concurrency of tabletnode for split tablet");
 DEFINE_int32(tera_master_max_load_concurrency, 5, "the max concurrency of tabletnode for load tablet");
+DEFINE_int32(tera_master_max_unload_concurrency, 5, "the max concurrency of tabletnode for unload tablet");
 DEFINE_int32(tera_master_load_interval, 300, "the delay interval (in sec) for load tablet");
 DEFINE_int32(tera_master_load_balance_period, 10000, "the period (in ms) for load balance policy execute");
 DEFINE_bool(tera_master_load_balance_table_grained, true, "whether the load balance policy only consider the specified table");


### PR DESCRIPTION
测试无明显异常，测试时最多700+ tablets
0. 代码还有待整理，个别异常待处理【主要是请review下实现思路，review通过后我再进一步修正】
1. 因为merge有点特殊，实现可以work，但可读性等方面还有很大的提升空间，先不要看merge相关的部分，其并发控制思路和 unload 等一致
2. 并发控制思路：以 unload 为例，如果当前某个ts上正在 unloading 的tablets 过多（达到某个阈值 ），则将 待unload 的tablet放入队列，
当某个tablet的unload执行成功、失败callback回来时，再从等待队列中选出tablet执行unload
3. 以上思路主要参考了 load 的并发控制，现在将 load/unload/merge/split 这4个操作的并发控制抽象出来统一处理了：
有一个名为spatula的class，实现压力抹平，其成员变量 m_doing_count 记录某个ts上 正在 unloading 的个数；成员变量 m_wait_list 是 等待队列。还有一些辅助调试的成员，会在正式代码中删除。
#