### PR TITLE
sst file size configurable

### DIFF
--- a/src/io/tablet_io.cc
+++ b/src/io/tablet_io.cc
@@ -1290,6 +1290,9 @@ void TabletIO::SetupOptionsForLG() {
                 << ", buffer_size:" << lg_info->memtable_ldb_write_buffer_size
                 << ", block_size:"  << lg_info->memtable_ldb_block_size;
         }
+        LOG(INFO) << ", sst_size: " << lg_schema.sst_size() << " Bytes.";
+        lg_info->sst_size = lg_schema.sst_size();
+        m_ldb_options.sst_size = lg_schema.sst_size();
         exist_lg_list->insert(lg_i);
         (*lg_info_list)[lg_i] = lg_info;
     }

--- a/src/leveldb/db/db_table.cc
+++ b/src/leveldb/db/db_table.cc
@@ -87,6 +87,7 @@ Options InitOptionsLG(const Options& options, uint32_t lg_id) {
     opt.use_memtable_on_leveldb = lg_info->use_memtable_on_leveldb;
     opt.memtable_ldb_write_buffer_size = lg_info->memtable_ldb_write_buffer_size;
     opt.memtable_ldb_block_size = lg_info->memtable_ldb_block_size;
+    opt.sst_size = lg_info->sst_size;
     return opt;
 }
 

--- a/src/leveldb/include/leveldb/options.h
+++ b/src/leveldb/include/leveldb/options.h
@@ -71,6 +71,8 @@ struct LG_info {
 
   size_t memtable_ldb_block_size;
 
+  int32_t sst_size;
+
   // Other LG properties
   // ...
 
@@ -81,7 +83,8 @@ struct LG_info {
         block_size(kDefaultBlockSize),
         use_memtable_on_leveldb(false),
         memtable_ldb_write_buffer_size(1 << 20),
-        memtable_ldb_block_size(kDefaultBlockSize) {}
+        memtable_ldb_block_size(kDefaultBlockSize),
+        sst_size(8000000) {}
 };
 
 // Options to control the behavior of a database (passed to DB::Open)
@@ -265,6 +268,9 @@ struct Options {
   size_t memtable_ldb_block_size;
 
   bool drop_base_level_del_in_compaction;
+
+  // sst file size, in bytes
+  int32_t sst_size;
 
   // Create an Options object with default values for all fields.
   Options();

--- a/src/leveldb/util/options.cc
+++ b/src/leveldb/util/options.cc
@@ -46,7 +46,8 @@ Options::Options()
       use_memtable_on_leveldb(false),
       memtable_ldb_write_buffer_size(1 << 20),
       memtable_ldb_block_size(kDefaultBlockSize),
-      drop_base_level_del_in_compaction(true) {
+      drop_base_level_del_in_compaction(true),
+      sst_size(8000000) {
 }
 
 }  // namespace leveldb

--- a/src/proto/table_schema.proto
+++ b/src/proto/table_schema.proto
@@ -24,6 +24,7 @@ message LocalityGroupSchema {
     optional bool use_memtable_on_leveldb = 8 [default = false];
     optional int32 memtable_ldb_write_buffer_size = 9 [default = 1]; //MB
     optional int32 memtable_ldb_block_size = 10 [default = 4]; //KB
+    optional int32 sst_size = 11 [default = 8000000]; // Bytes
 }
 
 message ColumnFamilySchema {

--- a/src/sdk/schema_impl.cc
+++ b/src/sdk/schema_impl.cc
@@ -102,7 +102,8 @@ LGDescImpl::LGDescImpl(const std::string& lg_name, int32_t id)
       _block_size(FLAGS_tera_tablet_write_block_size),
       _use_memtable_on_leveldb(false),
       _memtable_ldb_write_buffer_size(0),
-      _memtable_ldb_block_size(0){
+      _memtable_ldb_block_size(0),
+      _sst_size(8000000){
 }
 
 /// Id read only
@@ -172,6 +173,14 @@ int32_t LGDescImpl::MemtableLdbBlockSize() const {
 
 void LGDescImpl::SetMemtableLdbBlockSize(int32_t block_size) {
     _memtable_ldb_block_size = block_size;
+}
+
+int32_t LGDescImpl::SstSize() const {
+    return _sst_size;
+}
+
+void LGDescImpl::SetSstSize(int32_t sst_size) {
+    _sst_size = sst_size;
 }
 
 /// 表格名字仅允许使用字母、数字和下划线构造,长度不超过256

--- a/src/sdk/schema_impl.h
+++ b/src/sdk/schema_impl.h
@@ -112,6 +112,10 @@ public:
 
     void SetMemtableLdbBlockSize(int32_t block_size);
 
+    /// sst file size, in Bytes
+    int32_t SstSize() const;
+    void SetSstSize(int32_t sst_size);
+
 private:
     int32_t         _id;
     std::string     _name;
@@ -122,6 +126,7 @@ private:
     bool            _use_memtable_on_leveldb;
     int32_t         _memtable_ldb_write_buffer_size;
     int32_t         _memtable_ldb_block_size;
+    int32_t         _sst_size; // in bytes
 };
 
 /// 表描述符.

--- a/src/sdk/tera.h
+++ b/src/sdk/tera.h
@@ -133,6 +133,10 @@ public:
     virtual int32_t MemtableLdbBlockSize() const = 0;
     virtual void SetMemtableLdbBlockSize(int32_t block_size) = 0;
 
+    /// sst file size, in Bytes
+    virtual int32_t SstSize() const = 0;
+    virtual void SetSstSize(int32_t sst_size) = 0;
+
 private:
     LocalityGroupDescriptor(const LocalityGroupDescriptor&);
     void operator=(const LocalityGroupDescriptor&);


### PR DESCRIPTION
sst file size configurable

单位问题：
1. schema中存储的sst文件size值以byte为单位
1. 用户输入、显示给用户的size值以MB为单位

单位转换在sdk中实现。因为之前设计不当，整个系统全部使用以byte为单位的size值，为保证新程序兼容旧数据，所以后端依然以byte为单位，但sdk端采用MB为单位。