### PR TITLE
master task concurrency control with priority

### DIFF
--- a/depends.mk
+++ b/depends.mk
@@ -5,14 +5,14 @@
 #       automatically config this for you.
 ################################################################
 
-SOFA_PBRPC_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
-PROTOBUF_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
-SNAPPY_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
-ZOOKEEPER_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
-GFLAGS_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
-GLOG_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
-GPERFTOOLS_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
-BOOST_INCDIR=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
+SOFA_PBRPC_PREFIX=
+PROTOBUF_PREFIX=
+SNAPPY_PREFIX=
+ZOOKEEPER_PREFIX=
+GFLAGS_PREFIX=
+GLOG_PREFIX=
+GPERFTOOLS_PREFIX=
+BOOST_INCDIR=
 
 SOFA_PBRPC_INCDIR = $(SOFA_PBRPC_PREFIX)/include
 PROTOBUF_INCDIR = $(PROTOBUF_PREFIX)/include

--- a/depends.mk
+++ b/depends.mk
@@ -5,14 +5,14 @@
 #       automatically config this for you.
 ################################################################
 
-SOFA_PBRPC_PREFIX=
-PROTOBUF_PREFIX=
-SNAPPY_PREFIX=
-ZOOKEEPER_PREFIX=
-GFLAGS_PREFIX=
-GLOG_PREFIX=
-GPERFTOOLS_PREFIX=
-BOOST_INCDIR=
+SOFA_PBRPC_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
+PROTOBUF_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
+SNAPPY_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
+ZOOKEEPER_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
+GFLAGS_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
+GLOG_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
+GPERFTOOLS_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
+BOOST_INCDIR=$(HOME)/jx-tera-github/tera/thirdparty
 
 SOFA_PBRPC_INCDIR = $(SOFA_PBRPC_PREFIX)/include
 PROTOBUF_INCDIR = $(PROTOBUF_PREFIX)/include

--- a/depends.mk
+++ b/depends.mk
@@ -5,14 +5,14 @@
 #       automatically config this for you.
 ################################################################
 
-SOFA_PBRPC_PREFIX=
-PROTOBUF_PREFIX=
-SNAPPY_PREFIX=
-ZOOKEEPER_PREFIX=
-GFLAGS_PREFIX=
-GLOG_PREFIX=
-GPERFTOOLS_PREFIX=
-BOOST_INCDIR=
+SOFA_PBRPC_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
+PROTOBUF_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
+SNAPPY_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
+ZOOKEEPER_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
+GFLAGS_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
+GLOG_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
+GPERFTOOLS_PREFIX=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
+BOOST_INCDIR=/home/users/huangjinxiao/jx-tera-github/tera/thirdparty
 
 SOFA_PBRPC_INCDIR = $(SOFA_PBRPC_PREFIX)/include
 PROTOBUF_INCDIR = $(PROTOBUF_PREFIX)/include

--- a/depends.mk
+++ b/depends.mk
@@ -5,14 +5,14 @@
 #       automatically config this for you.
 ################################################################
 
-SOFA_PBRPC_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
-PROTOBUF_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
-SNAPPY_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
-ZOOKEEPER_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
-GFLAGS_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
-GLOG_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
-GPERFTOOLS_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
-BOOST_INCDIR=$(HOME)/jx-tera-github/tera/thirdparty
+SOFA_PBRPC_PREFIX=
+PROTOBUF_PREFIX=
+SNAPPY_PREFIX=
+ZOOKEEPER_PREFIX=
+GFLAGS_PREFIX=
+GLOG_PREFIX=
+GPERFTOOLS_PREFIX=
+BOOST_INCDIR=
 
 SOFA_PBRPC_INCDIR = $(SOFA_PBRPC_PREFIX)/include
 PROTOBUF_INCDIR = $(PROTOBUF_PREFIX)/include

--- a/depends.mk
+++ b/depends.mk
@@ -45,4 +45,4 @@ DEPS_LDPATH = -L$(SOFA_PBRPC_LIBDIR) -L$(PROTOBUF_LIBDIR) \
               -L$(GFLAGS_LIBDIR) -L$(GLOG_LIBDIR) \
               -L$(GPERFTOOLS_LIBDIR)
 DEPS_LDFLAGS = -lsofa-pbrpc -lprotobuf -lsnappy -lzookeeper_mt \
-               -lgflags -lglog -ltcmalloc -lunwind
+               -lgflags -lglog -ltcmalloc_minimal

--- a/depends.mk
+++ b/depends.mk
@@ -5,14 +5,14 @@
 #       automatically config this for you.
 ################################################################
 
-SOFA_PBRPC_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
-PROTOBUF_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
-SNAPPY_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
-ZOOKEEPER_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
-GFLAGS_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
-GLOG_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
-GPERFTOOLS_PREFIX=$(HOME)/jx-tera-github/tera/thirdparty
-BOOST_INCDIR=$(HOME)/jx-tera-github/tera/thirdparty
+SOFA_PBRPC_PREFIX=
+PROTOBUF_PREFIX=
+SNAPPY_PREFIX=
+ZOOKEEPER_PREFIX=
+GFLAGS_PREFIX=
+GLOG_PREFIX=
+GPERFTOOLS_PREFIX=
+BOOST_INCDIR=
 
 SOFA_PBRPC_INCDIR = $(SOFA_PBRPC_PREFIX)/include
 PROTOBUF_INCDIR = $(PROTOBUF_PREFIX)/include
@@ -45,4 +45,4 @@ DEPS_LDPATH = -L$(SOFA_PBRPC_LIBDIR) -L$(PROTOBUF_LIBDIR) \
               -L$(GFLAGS_LIBDIR) -L$(GLOG_LIBDIR) \
               -L$(GPERFTOOLS_LIBDIR)
 DEPS_LDFLAGS = -lsofa-pbrpc -lprotobuf -lsnappy -lzookeeper_mt \
-               -lgflags -lglog -ltcmalloc_minimal
+               -lgflags -lglog -ltcmalloc -lunwind

--- a/src/master/master_impl.cc
+++ b/src/master/master_impl.cc
@@ -50,6 +50,7 @@ DECLARE_bool(tera_zk_enabled);
 DECLARE_int64(tera_master_split_tablet_size);
 DECLARE_int64(tera_master_merge_tablet_size);
 DECLARE_bool(tera_master_kick_tabletnode_enabled);
+DECLARE_bool(tera_master_merge_enabled);
 DECLARE_int32(tera_master_kick_tabletnode_query_fail_times);
 
 DECLARE_double(tera_safemode_tablet_locality_ratio);
@@ -307,7 +308,6 @@ void MasterImpl::RestoreUserTablet(const std::vector<TabletMeta>& report_meta_li
             UnloadClosure* done =
                 NewClosure(this, &MasterImpl::UnloadTabletCallback,
                            unknown_tablet, FLAGS_tera_master_impl_retry_times);
-            //UnloadTabletAsync(unknown_tablet, done);
             TryUnloadTablet(unknown_tablet, done);
         } else {
             tablet->SetStatus(kTableReady);
@@ -610,7 +610,6 @@ void MasterImpl::DisableTable(const DisableTableRequest* request,
                 NewClosure(this, &MasterImpl::UnloadTabletCallback, tablet,
                            FLAGS_tera_master_impl_retry_times);
             TryUnloadTablet(tablet, done);
-            //UnloadTabletAsync(tablet, done);
         } else if (tablet->SetStatusIf(kTabletDisable, kTableOffLine, kTableDisable)) {
             WriteClosure* closure =
                 NewClosure(this, &MasterImpl::UpdateTabletRecordCallback, tablet,
@@ -1213,6 +1212,22 @@ void MasterImpl::LoadBalance() {
 
     m_load_balance_timer_id = kInvalidTimerId;
     EnableLoadBalanceTimer();
+
+    /* (jinxiao)
+    // try unload
+    std::vector<TabletNodePtr>::iterator node_it = all_node_list.begin();
+    for (; node_it != all_node_list.end(); ++node_it) {
+        TabletPtr next_tablet;
+        LOG(INFO) << "[LoadBalance] enter UnloadNextWaitTablet";
+        while ((*node_it)->UnloadNextWaitTablet(&next_tablet)) {
+            UnloadClosure* done =
+                NewClosure(this, &MasterImpl::UnloadTabletCallback, next_tablet,
+                           FLAGS_tera_master_impl_retry_times);
+            UnloadTabletAsync(next_tablet, done);
+        }
+        LOG(INFO) << "[LoadBalance] leave UnloadNextWaitTablet";
+    }  
+    */
 }
 
 void MasterImpl::TabletNodeLoadBalance(const std::string& tabletnode_addr,
@@ -1243,12 +1258,10 @@ void MasterImpl::TabletNodeLoadBalance(const std::string& tabletnode_addr,
         if (tablet->GetSchema().has_split_size() && tablet->GetSchema().split_size() > 0) {
             split_size = tablet->GetSchema().split_size();
         }
-        int64_t merge_size = FLAGS_tera_master_merge_tablet_size;
+        int64_t merge_size = 0;
         if (tablet->GetSchema().has_merge_size() && tablet->GetSchema().merge_size() > 0) {
             merge_size = tablet->GetSchema().merge_size();
         }
-        LOG(INFO) << "split_size: " << split_size
-            << "merge_size: " << merge_size;
         if (tablet->GetDataSize() < 0) {
             // tablet size is error, skip it
             continue;
@@ -1257,7 +1270,7 @@ void MasterImpl::TabletNodeLoadBalance(const std::string& tabletnode_addr,
             any_tablet_split = true;
             continue;
         } else if (tablet->GetDataSize() < (merge_size << 20)) {
-            // TryMergeTablet(tablet);
+            TryMergeTablet(tablet);
             continue;
         }
         if (tablet->GetStatus() == kTableReady) {
@@ -1480,7 +1493,6 @@ void MasterImpl::TabletNodeRecoveryCallback(std::string addr,
             UnloadClosure* done =
                 NewClosure(this, &MasterImpl::UnloadTabletCallback, unload_tablet,
                            FLAGS_tera_master_impl_retry_times);
-            //UnloadTabletAsync(unload_tablet, done);
             TryUnloadTablet(unload_tablet, done);
         } else if (tablet->SetStatusIf(kTableReady, kTabletPending)
             || tablet->SetStatusIf(kTableReady, kTableOffLine)) {
@@ -1948,8 +1960,7 @@ void MasterImpl::LoadTabletCallback(TabletPtr tablet, int32_t retry,
             ResumeMetaOperation();
             return;
         }
-        // TODO ???
-        // ProcessReadyTablet(tablet);
+        ProcessReadyTablet(tablet);
 
         // load next
         node->FinishLoad(tablet);
@@ -1985,7 +1996,6 @@ void MasterImpl::LoadTabletCallback(TabletPtr tablet, int32_t retry,
             UnloadClosure* done =
                 NewClosure(this, &MasterImpl::UnloadTabletCallback, tablet,
                            FLAGS_tera_master_impl_retry_times);
-            //UnloadTabletAsync(tablet, done);
             TryUnloadTablet(tablet, done);
             return;
         }
@@ -1998,7 +2008,6 @@ void MasterImpl::LoadTabletCallback(TabletPtr tablet, int32_t retry,
             NewClosure(this, &MasterImpl::UnloadTabletCallback, tablet,
                        FLAGS_tera_master_impl_retry_times);
         TryUnloadTablet(tablet, done);
-        //UnloadTabletAsync(tablet, done);
         return;
     }
 
@@ -2109,14 +2118,13 @@ void MasterImpl::UnloadTabletCallback(TabletPtr tablet, int32_t retry,
                 NewClosure(this, &MasterImpl::UnloadTabletCallback, next_tablet,
                            FLAGS_tera_master_impl_retry_times);
             UnloadTabletAsync(next_tablet, done);
-            //node->FinishUnload(next_tablet);// TODO need?
         }
         LOG(INFO) << "leave UnloadNextWaitTablet";
 
         if (tablet->SetStatusIf(kTableOffLine, kTableUnLoading)) {
             ProcessOffLineTablet(tablet);
             // unload success, try load
-            // TryLoadTablet(tablet);
+            TryLoadTablet(tablet);
         } else if (tablet->SetStatusIf(kTableOffLine, kTableOnLoad)) {
             ProcessOffLineTablet(tablet);
             // load fail but unload success, try reload
@@ -2162,18 +2170,6 @@ void MasterImpl::UnloadTabletCallback(TabletPtr tablet, int32_t retry,
         }
         return;
     }
-
-    LOG(INFO) << "enter UnloadNextWaitTablet2";
-    // unload next
-    TabletPtr next_tablet;
-    while (node->UnloadNextWaitTablet(&next_tablet)) {
-        UnloadClosure* done =
-            NewClosure(this, &MasterImpl::UnloadTabletCallback, next_tablet,
-                       FLAGS_tera_master_impl_retry_times);
-        UnloadTabletAsync(next_tablet, done);
-        //node->FinishUnload(next_tablet);// TODO need?
-    }
-    LOG(INFO) << "leave UnloadNextWaitTablet2";
 
     // fail
     if (failed) {
@@ -2820,7 +2816,6 @@ void MasterImpl::SplitTabletCallback(TabletPtr tablet,
             NewClosure(this, &MasterImpl::UnloadTabletCallback, tablet,
                        FLAGS_tera_master_impl_retry_times);
         TryUnloadTablet(tablet, done);
-        //UnloadTabletAsync(tablet, done);
         return;
     }
 
@@ -2869,7 +2864,30 @@ void MasterImpl::SplitTabletCallback(TabletPtr tablet,
     }
 }
 
-void MasterImpl::TryUnloadTablet(TabletPtr tablet, UnloadClosure* done){
+void MasterImpl::TryUnload4MergeTablet(TabletPtr tablet, UnloadClosure* done) {
+    if (!tablet->IsBound()) {
+        return;
+    }
+    std::string server_addr = tablet->GetServerAddr();
+    LOG(INFO) << "TryUnload4Merge: " << tablet->GetPath() << "at: " << server_addr;
+    TabletNodePtr node;
+    if (server_addr.empty()
+        || !m_tabletnode_manager->FindTabletNode(server_addr, &node)) {
+        LOG(ERROR) << "[unload4merge] invalid tablet to unload";
+        return;
+    }
+    if (!node->TryUnload4Merge(tablet)) {
+        LOG(INFO) << "[unload4merge] delay unload table " << tablet->GetPath()
+            << ", too many tablets are unloading on server: "
+            << server_addr;
+        return;
+    }
+    UnloadTabletAsync(tablet, done);
+    LOG(INFO) << "[unload4merge] request has sent : " << tablet->GetPath()
+        << ", on server : " << node->GetAddr();
+}
+
+void MasterImpl::TryUnloadTablet(TabletPtr tablet, UnloadClosure* done) {
     if (!tablet->IsBound()) {
         return;
     }
@@ -3068,7 +3086,6 @@ void MasterImpl::RetryUnloadTablet(TabletPtr tablet, int32_t retry_times) {
     UnloadClosure* done =
         NewClosure(this, &MasterImpl::UnloadTabletCallback, tablet, retry_times);
     TryUnloadTablet(tablet, done);
-    //UnloadTabletAsync(tablet, done);
 }
 
 bool MasterImpl::TrySplitTablet(TabletPtr tablet) {
@@ -3124,24 +3141,29 @@ bool MasterImpl::TryMergeTablet(TabletPtr tablet) {
         return false;
     }
 
+    m_unload4merge_pair.insert(std::pair<TabletPtr, TabletPtr>(tablet, tablet2));
+    m_unload4merge_pair.insert(std::pair<TabletPtr, TabletPtr>(tablet2, tablet));
+    Mutex* mu = new Mutex();
+    m_unload4merge_mutex.insert(
+            std::pair< std::pair<TabletPtr, TabletPtr>, Mutex* >(
+                std::pair<TabletPtr, TabletPtr>(tablet2, tablet), mu));
     LOG(INFO) << "[merge] begin merge tablet " << tablet->GetPath()
         << " and " << tablet2->GetPath();
-    MergeTabletAsync(tablet, tablet2);
+    MergeTabletAsync(tablet, tablet2, mu);
     return true;
 }
 
-void MasterImpl::MergeTabletAsync(TabletPtr tablet_p1, TabletPtr tablet_p2) {
+void MasterImpl::MergeTabletAsync(TabletPtr tablet_p1, TabletPtr tablet_p2, Mutex *mu) {
     if (tablet_p1->SetStatusIf(kTableUnLoading, kTableReady) &&
         tablet_p2->SetStatusIf(kTableUnLoading, kTableReady)) {
-        Mutex* mu = new Mutex();
         UnloadClosure* done1 =
             NewClosure(this, &MasterImpl::MergeTabletUnloadCallback, tablet_p1, tablet_p2, mu);
         UnloadClosure* done2 =
             NewClosure(this, &MasterImpl::MergeTabletUnloadCallback, tablet_p2, tablet_p1, mu);
-        //TryUnloadTablet(tablet_p1, done1);
-        //TryUnloadTablet(tablet_p2, done2);
-        UnloadTabletAsync(tablet_p1, done1);
-        UnloadTabletAsync(tablet_p2, done2);
+        TryUnload4MergeTablet(tablet_p1, done1);
+        TryUnload4MergeTablet(tablet_p2, done2);
+        //UnloadTabletAsync(tablet_p1, done1);
+        //UnloadTabletAsync(tablet_p2, done2);
     } else {
         LOG(WARNING) << "[merge] tablet not ready, merge failed and rollback.";
         tablet_p1->SetStatusIf(kTableReady, kTableUnLoading);
@@ -3282,6 +3304,45 @@ void MasterImpl::MergeTabletUnloadCallback(TabletPtr tablet, TabletPtr tablet2, 
     // unload success
     if (!failed && (status == kTabletNodeOk || status == kKeyNotInRange)) {
         LOG(INFO) << "[merge] unload tablet success, " << tablet;
+
+        // unload next for merge
+        TabletPtr next_tablet;
+        TabletPtr next_tablet2; // merge next_tablet && next_tablet2 into one tablet
+        std::map<TabletPtr, TabletPtr>::iterator it;
+        std::map<std::pair<TabletPtr, TabletPtr>, Mutex*>::iterator mutex_it;
+        node->FinishUnload4Merge(tablet);
+        if (m_unload4merge_pair.erase(tablet) != 1) {
+            LOG(ERROR) << "[merge] this tablet doesn't exist: " << tablet->GetPath();
+        }
+        LOG(INFO) << "enter UnloadNextWaitTablet";
+        while (node->Unload4MergeNextWaitTablet(&next_tablet)) {
+            it = m_unload4merge_pair.find(next_tablet);
+            if (it == m_unload4merge_pair.end()) {
+                LOG(ERROR) << "[merge] this tablet doesn't exist: "
+                    << tablet->GetPath();
+                continue;
+            }
+            next_tablet2 = it->second;
+
+            // get mutex for two tablet will be merged
+            mutex_it = m_unload4merge_mutex.find(std::pair<TabletPtr, TabletPtr>(
+                        next_tablet, next_tablet2));
+            if (mutex_it == m_unload4merge_mutex.end()) {
+                mutex_it = m_unload4merge_mutex.find(std::pair<TabletPtr, TabletPtr>(
+                            next_tablet2, next_tablet));
+                if (mutex_it == m_unload4merge_mutex.end()) {
+                    LOG(ERROR) << "[merge] mutex doesn't exist for "
+                        << next_tablet->GetPath() << " and " << next_tablet2->GetPath();
+                    continue;
+                }
+            }
+            UnloadClosure* done =
+            NewClosure(this, &MasterImpl::MergeTabletUnloadCallback, 
+                       next_tablet, next_tablet2, mutex_it->second);
+            UnloadTabletAsync(next_tablet, done);
+        }
+        LOG(INFO) << "leave UnloadNextWaitTablet";
+
         CHECK(tablet->SetStatusIf(kTableOnMerge, kTableUnLoading))
             << "[merge] tablet status not unloading";
         if (tablet2->GetStatus() == kTableOnMerge) {
@@ -4177,7 +4238,6 @@ void MasterImpl::TryMoveTablet(TabletPtr tablet, const std::string& server_addr)
             NewClosure(this, &MasterImpl::UnloadTabletCallback, tablet,
                        FLAGS_tera_master_impl_retry_times);
         TryUnloadTablet(tablet, done);
-        //UnloadTabletAsync(tablet, done);
     }
 }
 
@@ -4202,7 +4262,6 @@ void MasterImpl::ProcessReadyTablet(TabletPtr tablet) {
             NewClosure(this, &MasterImpl::UnloadTabletCallback, tablet,
                        FLAGS_tera_master_impl_retry_times);
         TryUnloadTablet(tablet, done);
-        //UnloadTabletAsync(tablet, done);
     }
 }
 

--- a/src/master/master_impl.cc
+++ b/src/master/master_impl.cc
@@ -1212,22 +1212,6 @@ void MasterImpl::LoadBalance() {
 
     m_load_balance_timer_id = kInvalidTimerId;
     EnableLoadBalanceTimer();
-
-    /* (jinxiao)
-    // try unload
-    std::vector<TabletNodePtr>::iterator node_it = all_node_list.begin();
-    for (; node_it != all_node_list.end(); ++node_it) {
-        TabletPtr next_tablet;
-        LOG(INFO) << "[LoadBalance] enter UnloadNextWaitTablet";
-        while ((*node_it)->UnloadNextWaitTablet(&next_tablet)) {
-            UnloadClosure* done =
-                NewClosure(this, &MasterImpl::UnloadTabletCallback, next_tablet,
-                           FLAGS_tera_master_impl_retry_times);
-            UnloadTabletAsync(next_tablet, done);
-        }
-        LOG(INFO) << "[LoadBalance] leave UnloadNextWaitTablet";
-    }  
-    */
 }
 
 void MasterImpl::TabletNodeLoadBalance(const std::string& tabletnode_addr,
@@ -3162,8 +3146,6 @@ void MasterImpl::MergeTabletAsync(TabletPtr tablet_p1, TabletPtr tablet_p2, Mute
             NewClosure(this, &MasterImpl::MergeTabletUnloadCallback, tablet_p2, tablet_p1, mu);
         TryUnload4MergeTablet(tablet_p1, done1);
         TryUnload4MergeTablet(tablet_p2, done2);
-        //UnloadTabletAsync(tablet_p1, done1);
-        //UnloadTabletAsync(tablet_p2, done2);
     } else {
         LOG(WARNING) << "[merge] tablet not ready, merge failed and rollback.";
         tablet_p1->SetStatusIf(kTableReady, kTableUnLoading);

--- a/src/master/master_impl.h
+++ b/src/master/master_impl.h
@@ -126,7 +126,6 @@ public:
     void DisableQueryTabletNodeTimer();
 
     bool GetMetaTabletAddr(std::string* addr);
-    void TryLoadTablet(TabletPtr tablet, std::string addr = "");
 
 private:
     typedef Closure<void, SnapshotRequest*, SnapshotResponse*, bool, int> SnapshotClosure;
@@ -198,7 +197,9 @@ private:
 
     void RetryLoadTablet(TabletPtr tablet, int32_t retry_times);
     void RetryUnloadTablet(TabletPtr tablet, int32_t retry_times);
+    void TryLoadTablet(TabletPtr tablet, std::string addr = "");
     bool TrySplitTablet(TabletPtr tablet);
+    void TryUnloadTablet(TabletPtr tablet, UnloadClosure* done);
     bool TryMergeTablet(TabletPtr tablet);
     void TryMoveTablet(TabletPtr tablet, const std::string& server_addr = "");
 

--- a/src/master/master_impl.h
+++ b/src/master/master_impl.h
@@ -5,13 +5,13 @@
 #ifndef TERA_MASTER_MASTER_IMPL_H_
 #define TERA_MASTER_MASTER_IMPL_H_
 
-#include <stdint.h>
 #include <semaphore.h>
+#include <stdint.h>
 #include <string>
 #include <vector>
 
-#include "common/event.h"
 #include "common/base/scoped_ptr.h"
+#include "common/event.h"
 #include "common/mutex.h"
 #include "common/thread_pool.h"
 #include "gflags/gflags.h"
@@ -29,18 +29,18 @@ namespace tera {
 
 class LoadTabletRequest;
 class LoadTabletResponse;
-class UnloadTabletRequest;
-class UnloadTabletResponse;
-class SplitTabletRequest;
-class SplitTabletResponse;
 class MergeTabletRequest;
 class MergeTabletResponse;
 class QueryRequest;
 class QueryResponse;
-class WriteTabletRequest;
-class WriteTabletResponse;
 class ScanTabletRequest;
 class ScanTabletResponse;
+class SplitTabletRequest;
+class SplitTabletResponse;
+class UnloadTabletRequest;
+class UnloadTabletResponse;
+class WriteTabletRequest;
+class WriteTabletResponse;
 
 namespace master {
 
@@ -60,6 +60,21 @@ public:
         kIsRunning = kMasterIsRunning,
         kOnRestore = kMasterOnRestore,
         kOnWait = kMasterOnWait
+    };
+
+    // great number comes great priority
+    enum ConcurrencyTaskPriority {
+        // unload
+        kTaskUnloadForDisable = 5,
+        kTaskUnload = 10,
+        kTaskUnloadForMerge = 15,
+        kTaskUnloadForBalance = 20,
+
+        // load
+        kTaskLoad = 10,
+
+        // split
+        kTaskSplit = 10
     };
 
     MasterImpl();
@@ -300,7 +315,7 @@ private:
                              SplitTabletResponse* response, bool failed,
                              int error_code);
 
-    void MergeTabletAsync(TabletPtr tablet_p1, TabletPtr tablet_p2, Mutex *mu);
+    void MergeTabletAsync(TabletPtr tablet_p1, TabletPtr tablet_p2);
     void MergeTabletAsyncPhase2(TabletPtr tablet_p1, TabletPtr tablet_p2);
     void MergeTabletUnloadCallback(TabletPtr tablet, TabletPtr tablet2, Mutex* mutex,
                                            UnloadTabletRequest* request,

--- a/src/master/master_impl.h
+++ b/src/master/master_impl.h
@@ -200,6 +200,7 @@ private:
     void TryLoadTablet(TabletPtr tablet, std::string addr = "");
     bool TrySplitTablet(TabletPtr tablet);
     void TryUnloadTablet(TabletPtr tablet, UnloadClosure* done);
+    void TryUnload4MergeTablet(TabletPtr tablet, UnloadClosure* done);
     bool TryMergeTablet(TabletPtr tablet);
     void TryMoveTablet(TabletPtr tablet, const std::string& server_addr = "");
 
@@ -299,7 +300,7 @@ private:
                              SplitTabletResponse* response, bool failed,
                              int error_code);
 
-    void MergeTabletAsync(TabletPtr tablet_p1, TabletPtr tablet_p2);
+    void MergeTabletAsync(TabletPtr tablet_p1, TabletPtr tablet_p2, Mutex *mu);
     void MergeTabletAsyncPhase2(TabletPtr tablet_p1, TabletPtr tablet_p2);
     void MergeTabletUnloadCallback(TabletPtr tablet, TabletPtr tablet2, Mutex* mutex,
                                            UnloadTabletRequest* request,
@@ -491,6 +492,9 @@ private:
     std::set<std::string> m_gc_tabletnodes;
     int64_t m_gc_timer_id;
     bool m_gc_query_enable;
+
+    std::map<TabletPtr, TabletPtr> m_unload4merge_pair;
+    std::map<std::pair<TabletPtr, TabletPtr>, Mutex*> m_unload4merge_mutex;
 };
 
 } // namespace master

--- a/src/master/tabletnode_manager.cc
+++ b/src/master/tabletnode_manager.cc
@@ -30,9 +30,8 @@ Spatula::Spatula() :
 
 Spatula::~Spatula() {
     if (!m_wait_list.empty()) {
-        LOG(INFO) << "~spatula";
         Print();
-        LOG(FATAL) << "fatal";
+        LOG(FATAL) << "destruct a non empty spatula!";
     }
 }
 
@@ -86,16 +85,14 @@ uint32_t Spatula::PushCount() {
 
 TabletNode::TabletNode() : m_state(kOffLine),
     m_report_status(kTabletNodeInit), m_data_size(0), m_load(0),
-    m_update_time(0), m_query_fail_count(0), m_plan_move_in_count(0),
-    m_load_spatula(), m_unload_spatula(), m_unload4merge_spatula(), m_split_spatula() {
+    m_update_time(0), m_query_fail_count(0), m_plan_move_in_count(0) {
     m_info.set_addr("");
 }
 
 TabletNode::TabletNode(const std::string& addr, const std::string& uuid)
     : m_addr(addr), m_uuid(uuid), m_state(kOffLine),
       m_report_status(kTabletNodeInit), m_data_size(0), m_load(0),
-      m_update_time(0), m_query_fail_count(0), m_plan_move_in_count(0),
-      m_load_spatula(), m_unload_spatula(), m_unload4merge_spatula(), m_split_spatula() {
+      m_update_time(0), m_query_fail_count(0), m_plan_move_in_count(0) {
     m_info.set_addr(addr);
 }
 

--- a/src/master/tabletnode_manager.cc
+++ b/src/master/tabletnode_manager.cc
@@ -11,6 +11,7 @@
 DECLARE_string(tera_master_meta_table_name);
 DECLARE_int32(tera_master_max_load_concurrency);
 DECLARE_int32(tera_master_max_split_concurrency);
+DECLARE_int32(tera_master_max_unload_concurrency);
 DECLARE_int32(tera_master_load_interval);
 DECLARE_double(tera_master_load_balance_size_overload_ratio);
 DECLARE_bool(tera_master_meta_isolate_enabled);
@@ -18,22 +19,92 @@ DECLARE_bool(tera_master_meta_isolate_enabled);
 namespace tera {
 namespace master {
 
+class Spatula;
+
+Spatula::Spatula() : 
+    m_doing_count(0),
+    m_wait_list(),
+    m_pop_count(0),
+    m_push_count(0) {
+}
+
+Spatula::~Spatula() {
+    if (!m_wait_list.empty()) {
+        LOG(INFO) << "~spatula"
+            << ", the pop-count:" << m_pop_count
+            << ", the push-count:" << m_push_count;
+        Print();
+        LOG(FATAL) << "fatal";
+    }
+}
+
+bool Spatula::IsWaitListEmpty() {
+    return m_wait_list.empty();
+}
+
+void Spatula::Push(TabletPtr tablet) {
+    m_wait_list.push_back(tablet);
+    m_push_count++;
+}
+
+TabletPtr Spatula::Pop() {
+    TabletPtr t = m_wait_list.front();
+    m_wait_list.pop_front();
+    m_pop_count++;
+    return t;
+}
+
+uint32_t Spatula::GetDoingCount() const {
+    return m_doing_count;
+}
+
+void Spatula::DoingCountPlusOne(){
+    m_doing_count++;
+}
+
+void Spatula::DoingCountMinusOne() {
+    CHECK(m_doing_count > 0) << "pop-count: " << m_pop_count
+        << "push-count: " << m_push_count;
+    m_doing_count--;
+}
+
+// print all item in wait list, for debug
+void Spatula::Print() {
+    LOG(INFO) << "[spatula] print start..." << m_wait_list.size();
+    for (std::list<TabletPtr>::iterator it = m_wait_list.begin();
+         it != m_wait_list.end(); ++it) {
+            LOG(INFO) << (*it)->GetPath();
+    }
+    LOG(INFO) << "[spatula] print done, doing count: " << m_doing_count;
+}
+
+uint32_t Spatula::PopCount() {
+    return m_pop_count;
+}
+
+uint32_t Spatula::PushCount() {
+    return m_push_count;
+}
+
 TabletNode::TabletNode() : m_state(kOffLine),
     m_report_status(kTabletNodeInit), m_data_size(0), m_load(0),
-    m_update_time(0), m_query_fail_count(0), m_onload_count(0),
-    m_onsplit_count(0), m_plan_move_in_count(0) {
+    m_update_time(0), m_query_fail_count(0), m_plan_move_in_count(0),
+    m_load_spatula(), m_unload_spatula(), m_split_spatula() {
     m_info.set_addr("");
 }
 
 TabletNode::TabletNode(const std::string& addr, const std::string& uuid)
     : m_addr(addr), m_uuid(uuid), m_state(kOffLine),
       m_report_status(kTabletNodeInit), m_data_size(0), m_load(0),
-      m_update_time(0), m_query_fail_count(0), m_onload_count(0),
-      m_onsplit_count(0), m_plan_move_in_count(0) {
+      m_update_time(0), m_query_fail_count(0), m_plan_move_in_count(0),
+      m_load_spatula(), m_unload_spatula(), m_split_spatula() {
     m_info.set_addr(addr);
 }
 
-TabletNode::~TabletNode() {}
+TabletNode::~TabletNode() {
+    LOG(INFO) << "dests" << " addr: " << m_addr;
+    m_unload_spatula.Print();
+}
 
 TabletNodeInfo TabletNode::GetInfo() {
     MutexLock lock(&m_mutex);
@@ -98,6 +169,21 @@ bool TabletNode::MayLoadNow() {
     return false;
 }
 
+bool TabletNode::TryUnload(TabletPtr tablet) {
+    MutexLock lock(&m_mutex);
+    if (m_unload_spatula.IsWaitListEmpty()
+        && m_unload_spatula.GetDoingCount() < static_cast<uint32_t>(FLAGS_tera_master_max_unload_concurrency)) {
+        m_unload_spatula.DoingCountPlusOne();
+        LOG(INFO) << "[unload] doing count:" << m_unload_spatula.GetDoingCount()
+                  << ", waitlist:" << (m_unload_spatula.IsWaitListEmpty() ? "empty":"not empty");
+        return true;
+    }
+    m_unload_spatula.Push(tablet);
+    LOG(INFO) << "[unload] Push done, the push-count: " << m_unload_spatula.PushCount();
+    m_unload_spatula.Print();
+    return false;
+}
+
 bool TabletNode::TryLoad(TabletPtr tablet) {
     MutexLock lock(&m_mutex);
     m_data_size += tablet->GetDataSize();
@@ -108,17 +194,17 @@ bool TabletNode::TryLoad(TabletPtr tablet) {
     }
     //VLOG(5) << "load on: " << m_addr << ", size: " << tablet->GetDataSize()
     //      << ", total size: " << m_data_size;
-    if (m_wait_load_list.empty()
-        && m_onload_count < static_cast<uint32_t>(FLAGS_tera_master_max_load_concurrency)) {
+    if (m_load_spatula.IsWaitListEmpty()
+        && m_load_spatula.GetDoingCount() < static_cast<uint32_t>(FLAGS_tera_master_max_load_concurrency)) {
         BeginLoad();
         return true;
     }
-    m_wait_load_list.push_back(tablet);
+    m_load_spatula.Push(tablet);
     return false;
 }
 
 void TabletNode::BeginLoad() {
-    ++m_onload_count;
+    m_load_spatula.DoingCountPlusOne();
     m_recent_load_time_list.push_back(get_micros());
     uint32_t list_size = m_recent_load_time_list.size();
     if (list_size > static_cast<uint32_t>(FLAGS_tera_master_max_load_concurrency)) {
@@ -127,24 +213,51 @@ void TabletNode::BeginLoad() {
     }
 }
 
+bool TabletNode::FinishUnload(TabletPtr tablet) {
+    MutexLock lock(&m_mutex);
+    m_unload_spatula.DoingCountMinusOne();
+    return true;
+}
+
+bool TabletNode::FinishSplit(TabletPtr tablet) {
+    MutexLock lock(&m_mutex);
+    m_split_spatula.DoingCountMinusOne();
+    return true;
+}
+
 bool TabletNode::FinishLoad(TabletPtr tablet) {
     MutexLock lock(&m_mutex);
-    assert(m_onload_count > 0);
-    --m_onload_count;
+    m_load_spatula.DoingCountMinusOne();
+    return true;
+}
+
+bool TabletNode::UnloadNextWaitTablet(TabletPtr* tablet) {
+    MutexLock lock(&m_mutex);
+    if (m_unload_spatula.GetDoingCount() 
+        >= static_cast<uint32_t>(FLAGS_tera_master_max_unload_concurrency)) {
+        LOG(INFO) << "[unload] up to top";
+        return false;
+    }
+    if (m_unload_spatula.IsWaitListEmpty()) {
+        LOG(INFO) << "[unload] wait list is empty";
+        return false;
+    }
+    *tablet = m_unload_spatula.Pop();
+    LOG(INFO) << "[unload] pop() : " << (*tablet)->GetPath() 
+        << ", the pop-count: " << m_unload_spatula.PopCount();
+    m_unload_spatula.DoingCountPlusOne();
     return true;
 }
 
 bool TabletNode::LoadNextWaitTablet(TabletPtr* tablet) {
     MutexLock lock(&m_mutex);
-    if (m_onload_count >= static_cast<uint32_t>(FLAGS_tera_master_max_load_concurrency)) {
+    if (m_load_spatula.GetDoingCount() >= static_cast<uint32_t>(FLAGS_tera_master_max_load_concurrency)) {
         return false;
     }
-    std::list<TabletPtr>::iterator it = m_wait_load_list.begin();
-    if (it == m_wait_load_list.end()) {
+    if (m_load_spatula.IsWaitListEmpty()) {
         return false;
     }
-    *tablet = *it;
-    m_wait_load_list.pop_front();
+    *tablet = m_load_spatula.Pop();
     BeginLoad();
     return true;
 }
@@ -154,33 +267,27 @@ bool TabletNode::TrySplit(TabletPtr tablet) {
     m_data_size -= tablet->GetDataSize();
 //    VLOG(5) << "split on: " << m_addr << ", size: " << tablet->GetDataSize()
 //        << ", total size: " << m_data_size;
-    if (m_wait_split_list.empty()
-        && m_onsplit_count < static_cast<uint32_t>(FLAGS_tera_master_max_split_concurrency)) {
-        ++m_onsplit_count;
+    if (m_split_spatula.IsWaitListEmpty()
+        && m_split_spatula.GetDoingCount() < static_cast<uint32_t>(FLAGS_tera_master_max_split_concurrency)) {
+        m_split_spatula.DoingCountPlusOne();
+        LOG(INFO) << "[new split] after plus : " << m_split_spatula.GetDoingCount();
         return true;
     }
-    m_wait_split_list.push_back(tablet);
+    m_split_spatula.Push(tablet);
     return false;
-}
-
-bool TabletNode::FinishSplit(TabletPtr tablet) {
-    MutexLock lock(&m_mutex);
-    --m_onsplit_count;
-    return true;
 }
 
 bool TabletNode::SplitNextWaitTablet(TabletPtr* tablet) {
     MutexLock lock(&m_mutex);
-    if (m_onsplit_count >= static_cast<uint32_t>(FLAGS_tera_master_max_split_concurrency)) {
+    if (m_split_spatula.GetDoingCount() 
+        >= static_cast<uint32_t>(FLAGS_tera_master_max_split_concurrency)) {
         return false;
     }
-    std::list<TabletPtr>::iterator it = m_wait_split_list.begin();
-    if (it == m_wait_split_list.end()) {
+    if (m_split_spatula.IsWaitListEmpty()) {
         return false;
     }
-    *tablet = *it;
-    m_wait_split_list.pop_front();
-    ++m_onsplit_count;
+    *tablet = m_split_spatula.Pop();
+    m_split_spatula.DoingCountPlusOne();
     return true;
 }
 
@@ -303,8 +410,8 @@ void TabletNodeManager::UpdateTabletNode(const std::string& addr,
     node->m_table_size = state.m_table_size;
 
     node->m_info.set_status_m(NodeStateToString(node->m_state));
-    node->m_info.set_tablet_onload(node->m_onload_count);
-    node->m_info.set_tablet_onsplit(node->m_onsplit_count);
+    node->m_info.set_tablet_onload(node->m_load_spatula.GetDoingCount());
+    node->m_info.set_tablet_onsplit(node->m_split_spatula.GetDoingCount());
     VLOG(15) << "update tabletnode : " << addr;
 }
 

--- a/src/master/tabletnode_manager.h
+++ b/src/master/tabletnode_manager.h
@@ -30,6 +30,28 @@ enum NodeState {
 
 std::string NodeStateToString(NodeState state);
 
+class Spatula {
+public:
+    Spatula();
+    ~Spatula();
+    bool IsWaitListEmpty();
+    void Push(TabletPtr tablet);
+    TabletPtr Spatula::Pop();
+    uint32_t Spatula::GetDoingCount() const;
+    void Spatula::DoingCountPlusOne();
+    void Spatula::DoingCountMinusOne();
+    // print all item in wait list, for debug
+    void Spatula::Print();
+    uint32_t PushCount();
+    uint32_t PopCount();
+
+private:
+    uint32_t m_doing_count;
+    std::list<TabletPtr> m_wait_list;
+    uint32_t m_pop_count;
+    uint32_t m_push_count;
+};
+
 struct TabletNode {
     mutable Mutex m_mutex;
     std::string m_addr;
@@ -45,11 +67,16 @@ struct TabletNode {
     std::map<std::string, uint64_t> m_table_size;
 
     uint32_t m_query_fail_count;
-    uint32_t m_onload_count;
-    uint32_t m_onsplit_count;
+    //uint32_t m_onload_count;
+    //uint32_t m_onsplit_count;
+    //uint32_t m_onunload_count;
     uint32_t m_plan_move_in_count;
-    std::list<TabletPtr> m_wait_load_list;
-    std::list<TabletPtr> m_wait_split_list;
+    //std::list<TabletPtr> m_wait_load_list;
+    //std::list<TabletPtr> m_wait_split_list;
+    //std::list<TabletPtr> m_wait_unload_list;
+    Spatula m_load_spatula;
+    Spatula m_unload_spatula;
+    Spatula m_split_spatula;
 
     // The start time of recent load operation.
     // Used to tell if node load too many tablets within short time.
@@ -81,6 +108,11 @@ struct TabletNode {
     bool TrySplit(TabletPtr tablet);
     bool FinishSplit(TabletPtr tablet);
     bool SplitNextWaitTablet(TabletPtr* tablet);
+
+    bool TryUnload(TabletPtr tablet);
+    void BeginUnload();
+    bool FinishUnload(TabletPtr tablet);
+    bool UnloadNextWaitTablet(TabletPtr* tablet);
 
     NodeState GetState();
     bool SetState(NodeState new_state, NodeState* old_state);

--- a/src/master/tabletnode_manager.h
+++ b/src/master/tabletnode_manager.h
@@ -70,12 +70,9 @@ struct TabletNode {
     uint32_t m_query_fail_count;
     uint32_t m_plan_move_in_count;
     
-    //Spatula m_load_spatula;
-    TaskSpatula m_load_spatula2;
-
-    Spatula m_unload_spatula;
-    Spatula m_unload4merge_spatula;
-    Spatula m_split_spatula;
+    TaskSpatula m_load_spatula;
+    TaskSpatula m_unload_spatula;
+    TaskSpatula m_split_spatula;
 
     // The start time of recent load operation.
     // Used to tell if node load too many tablets within short time.
@@ -98,25 +95,6 @@ struct TabletNode {
 
     // To tell if node load too many tablets within short time.
     bool MayLoadNow();
-
-    //bool TryLoad(TabletPtr tablet);
-    //void BeginLoad();
-    //bool FinishLoad(TabletPtr tablet);
-    //bool LoadNextWaitTablet(TabletPtr* tablet);
-
-    bool TrySplit(TabletPtr tablet);
-    bool FinishSplit(TabletPtr tablet);
-    bool SplitNextWaitTablet(TabletPtr* tablet);
-
-    bool TryUnload(TabletPtr tablet);
-    void BeginUnload();
-    bool FinishUnload(TabletPtr tablet);
-    bool UnloadNextWaitTablet(TabletPtr* tablet);
-
-    bool TryUnload4Merge(TabletPtr tablet);
-    void BeginUnload4Merge();
-    bool FinishUnload4Merge(TabletPtr tablet);
-    bool Unload4MergeNextWaitTablet(TabletPtr* tablet);
 
     NodeState GetState();
     bool SetState(NodeState new_state, NodeState* old_state);

--- a/src/master/tabletnode_manager.h
+++ b/src/master/tabletnode_manager.h
@@ -76,6 +76,7 @@ struct TabletNode {
     //std::list<TabletPtr> m_wait_unload_list;
     Spatula m_load_spatula;
     Spatula m_unload_spatula;
+    Spatula m_unload4merge_spatula;
     Spatula m_split_spatula;
 
     // The start time of recent load operation.
@@ -113,6 +114,11 @@ struct TabletNode {
     void BeginUnload();
     bool FinishUnload(TabletPtr tablet);
     bool UnloadNextWaitTablet(TabletPtr* tablet);
+
+    bool TryUnload4Merge(TabletPtr tablet);
+    void BeginUnload4Merge();
+    bool FinishUnload4Merge(TabletPtr tablet);
+    bool TabletNode::Unload4MergeNextWaitTablet(TabletPtr* tablet);
 
     NodeState GetState();
     bool SetState(NodeState new_state, NodeState* old_state);

--- a/src/master/tabletnode_manager.h
+++ b/src/master/tabletnode_manager.h
@@ -36,12 +36,12 @@ public:
     ~Spatula();
     bool IsWaitListEmpty();
     void Push(TabletPtr tablet);
-    TabletPtr Spatula::Pop();
-    uint32_t Spatula::GetDoingCount() const;
-    void Spatula::DoingCountPlusOne();
-    void Spatula::DoingCountMinusOne();
+    TabletPtr Pop();
+    uint32_t GetDoingCount() const;
+    void DoingCountPlusOne();
+    void DoingCountMinusOne();
     // print all item in wait list, for debug
-    void Spatula::Print();
+    void Print();
     uint32_t PushCount();
     uint32_t PopCount();
 
@@ -118,7 +118,7 @@ struct TabletNode {
     bool TryUnload4Merge(TabletPtr tablet);
     void BeginUnload4Merge();
     bool FinishUnload4Merge(TabletPtr tablet);
-    bool TabletNode::Unload4MergeNextWaitTablet(TabletPtr* tablet);
+    bool Unload4MergeNextWaitTablet(TabletPtr* tablet);
 
     NodeState GetState();
     bool SetState(NodeState new_state, NodeState* old_state);

--- a/src/master/tabletnode_manager.h
+++ b/src/master/tabletnode_manager.h
@@ -16,6 +16,7 @@
 #include "common/thread_pool.h"
 
 #include "master/tablet_manager.h"
+#include "master/task_spatula.h"
 #include "proto/proto_helper.h"
 
 namespace tera {
@@ -67,14 +68,11 @@ struct TabletNode {
     std::map<std::string, uint64_t> m_table_size;
 
     uint32_t m_query_fail_count;
-    //uint32_t m_onload_count;
-    //uint32_t m_onsplit_count;
-    //uint32_t m_onunload_count;
     uint32_t m_plan_move_in_count;
-    //std::list<TabletPtr> m_wait_load_list;
-    //std::list<TabletPtr> m_wait_split_list;
-    //std::list<TabletPtr> m_wait_unload_list;
-    Spatula m_load_spatula;
+    
+    //Spatula m_load_spatula;
+    TaskSpatula m_load_spatula2;
+
     Spatula m_unload_spatula;
     Spatula m_unload4merge_spatula;
     Spatula m_split_spatula;
@@ -101,10 +99,10 @@ struct TabletNode {
     // To tell if node load too many tablets within short time.
     bool MayLoadNow();
 
-    bool TryLoad(TabletPtr tablet);
-    void BeginLoad();
-    bool FinishLoad(TabletPtr tablet);
-    bool LoadNextWaitTablet(TabletPtr* tablet);
+    //bool TryLoad(TabletPtr tablet);
+    //void BeginLoad();
+    //bool FinishLoad(TabletPtr tablet);
+    //bool LoadNextWaitTablet(TabletPtr* tablet);
 
     bool TrySplit(TabletPtr tablet);
     bool FinishSplit(TabletPtr tablet);

--- a/src/master/task_spatula.cc
+++ b/src/master/task_spatula.cc
@@ -1,0 +1,65 @@
+// Copyright (c) 2015, Baidu.com, Inc. All Rights Reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+// Description:  concurrency control with priority for (load/unload/split/merge)
+
+#include "task_spatula.h"
+
+namespace tera {
+namespace master {
+
+TaskSpatula::TaskSpatula(int32_t max)
+    :m_pending_count(0), m_running_count(0), m_max_concurrency(max) {}
+
+TaskSpatula::~TaskSpatula() {
+    assert(m_queue.size() == 0); // TODO copy from ts-a to ts-b, clear m_queue of a
+}
+
+void TaskSpatula::EnQueueTask(concurrency_task_t atask) {
+    MutexLock lock(&m_mutex);
+    m_queue.push(atask);
+    m_pending_count++;
+}
+
+bool TaskSpatula::DeQueueTask(concurrency_task_t *atask) {
+    MutexLock lock(&m_mutex);
+    assert(atask != NULL);
+    if(m_queue.size() <= 0) {
+        return false;
+    }
+    *atask = m_queue.top();
+    m_queue.pop();
+    m_pending_count--;
+    return true;
+}
+
+void TaskSpatula::FinishTask() {
+    MutexLock lock(&m_mutex);
+    assert(m_running_count > 0);
+    m_running_count--;
+}
+
+void TaskSpatula::TryDrain() {
+    boost::function<void ()> dummy_func = boost::bind(&TaskSpatula::TryDrain, this);
+    concurrency_task_t atask("dummy data", dummy_func);
+    while(m_running_count < m_max_concurrency
+          && DeQueueTask(&atask)) {
+        atask.async_call();
+        {
+            MutexLock lock(&m_mutex);
+            m_running_count++;
+        }
+    }
+
+    /*  for debug
+    if (m_running_count < m_max_concurrency) {
+        LOG(INFO) << "[task spatula] queue is empty";
+    } else {
+        LOG(INFO) << "[task spatula] m_running_count : " << m_running_count; 
+    } 
+    */
+}
+
+} // namespace master
+} // namespace tera

--- a/src/master/task_spatula.cc
+++ b/src/master/task_spatula.cc
@@ -16,13 +16,13 @@ TaskSpatula::~TaskSpatula() {
     assert(m_queue.size() == 0); // TODO copy from ts-a to ts-b, clear m_queue of a
 }
 
-void TaskSpatula::EnQueueTask(concurrency_task_t atask) {
+void TaskSpatula::EnQueueTask(const ConcurrencyTask& atask) {
     MutexLock lock(&m_mutex);
     m_queue.push(atask);
     m_pending_count++;
 }
 
-bool TaskSpatula::DeQueueTask(concurrency_task_t *atask) {
+bool TaskSpatula::DeQueueTask(ConcurrencyTask* atask) {
     MutexLock lock(&m_mutex);
     assert(atask != NULL);
     if(m_queue.size() <= 0) {
@@ -42,7 +42,7 @@ void TaskSpatula::FinishTask() {
 
 void TaskSpatula::TryDrain() {
     boost::function<void ()> dummy_func = boost::bind(&TaskSpatula::TryDrain, this);
-    concurrency_task_t atask("dummy data", dummy_func);
+    ConcurrencyTask atask(0, dummy_func);
     while(m_running_count < m_max_concurrency
           && DeQueueTask(&atask)) {
         atask.async_call();
@@ -51,14 +51,10 @@ void TaskSpatula::TryDrain() {
             m_running_count++;
         }
     }
+}
 
-    /*  for debug
-    if (m_running_count < m_max_concurrency) {
-        LOG(INFO) << "[task spatula] queue is empty";
-    } else {
-        LOG(INFO) << "[task spatula] m_running_count : " << m_running_count; 
-    } 
-    */
+int32_t TaskSpatula::GetRunningCount() {
+    return m_running_count;
 }
 
 } // namespace master

--- a/src/master/task_spatula.h
+++ b/src/master/task_spatula.h
@@ -1,0 +1,110 @@
+// Copyright (c) 2015, Baidu.com, Inc. All Rights Reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+// Description:  concurrency control with priority for (load/unload/split/merge)
+
+#ifndef TERA_MASTER_TASK_SPATULA_H_
+#define TERA_MASTER_TASK_SPATULA_H_
+
+#include <boost/bind.hpp>
+#include <boost/function.hpp>
+#include <glog/logging.h>
+#include <map>
+#include <queue>
+
+#include "common/mutex.h"
+
+namespace tera {
+namespace master {
+
+// TODO (jinxiao) : pluggable priority policy
+static int32_t GetTaskPriority(std::string& type) {
+    // great number comes great priority
+    static std::map<std::string, int32_t> priority_dict;
+
+    // unload
+    priority_dict["unload-disable-table"] = 5;
+    priority_dict["unload-merge"]         = 10;
+    priority_dict["unload-balance-move"]  = 20;
+
+    // load
+    priority_dict["load"]                 = 10;
+
+    // split
+    priority_dict["split"]                = 10;
+
+    /* works with C++ 11 but not here, what a sad story :(
+    static std::map<std::string, int32_t> priority_dict = {
+        // unload
+        {"unload-disable-table",  5},
+        {"unload-merge",         10},
+        {"unload-balance-move",  20},
+
+        // load
+        {"load",                 10},
+
+        // split
+        {"split",                10}, 
+    }; 
+    */
+    std::map<std::string, int32_t>::const_iterator it = priority_dict.find(type);
+    assert(it != priority_dict.end()); // "unknown task type";
+    return it->second;
+}
+
+// type of item in concurrency control queue
+struct concurrency_task_t {
+    std::string type; // "disable-unload" | "merge-unload" | "balance-unload" | ... | "load" | "split"
+    boost::function<void ()> async_call;
+
+    //concurrency_task_t() {}
+    concurrency_task_t(std::string atype, boost::function<void ()>& aasync_call)
+        : type(atype), async_call(aasync_call) {}
+
+    friend bool operator< (concurrency_task_t t1, concurrency_task_t t2) {
+        int32_t t1_priority = GetTaskPriority(t1.type);
+        int32_t t2_priority = GetTaskPriority(t2.type);
+        return t1_priority < t2_priority;
+    }
+};
+
+class TaskSpatula {
+public:
+    TaskSpatula(int32_t concurrency_max);
+    ~TaskSpatula();
+
+    // the function adds a item(`task') to concurrency control queue
+    void EnQueueTask(concurrency_task_t task);
+
+    // the function deletes a item (`task') from concurrency control queue
+    // and stores the deleted item at the location given by `task'.
+    //
+    // return value:
+    // if concurrency control queue is empty before deletes, return false;
+    // otherwise, returns true.
+    bool DeQueueTask(concurrency_task_t *task);
+
+    // the function do its best to executes task in concurrency control queue,
+    // until:
+    // 1) reachs the threshold (running count >= concurrency_max), 
+    //    concurrency_max is the parameter of constructor.
+    // 2) concurrency control queue has no item anymore
+    void TryDrain();
+
+    // the function minus (count of running task) one
+    // users must call this function when a async task done!
+    void FinishTask();
+
+private:
+    mutable Mutex m_mutex;
+    std::priority_queue<concurrency_task_t> m_queue; // concurrency control queue
+    int32_t m_pending_count; // count of task in concurrency control queue
+    int32_t m_running_count; // count of task is running
+    int32_t m_max_concurrency;
+};
+
+} // namespace master
+} // namespace tera
+
+#endif  // TERA_MASTER_TASK_SPATULA_H_

--- a/src/proto/tabletnode.proto
+++ b/src/proto/tabletnode.proto
@@ -44,6 +44,7 @@ message TabletNodeInfo {
 
     optional string status_m = 31;
     optional uint32 tablet_onload = 32;
+    optional uint32 tablet_onunload = 45;
     optional uint32 tablet_onsplit = 33;
 
     repeated ExtraTsInfo extra_info = 40;

--- a/src/sdk/sdk_utils.cc
+++ b/src/sdk/sdk_utils.cc
@@ -413,15 +413,19 @@ bool SetTableProperties(const PropertyList& props, TableDescriptor* desc) {
                 return false;
             }
         } else if (prop.first == "splitsize") {
-            int splitsize = atoi(prop.second.c_str());
+            int64_t splitsize = atoi(prop.second.c_str());
             if (splitsize < 0) { // splitsize == 0 : split closed
                 LOG(ERROR) << "illegal value: " << prop.second
                     << " for property: " << prop.first;
                 return false;
             }
             desc->SetSplitSize(splitsize);
+            int64_t mergesize = desc->MergeSize();
+            if (mergesize > 0) {
+                desc->SetMergeSize(splitsize/5); // TODO (jinxiao) a better way?
+            }
         } else if (prop.first == "mergesize") {
-            int mergesize = atoi(prop.second.c_str());
+            int64_t mergesize = atoi(prop.second.c_str());
             if (mergesize < 0) { // mergesize == 0 : merge closed
                 LOG(ERROR) << "illegal value: " << prop.second
                     << " for property: " << prop.first;

--- a/src/tabletnode/remote_tabletnode.cc
+++ b/src/tabletnode/remote_tabletnode.cc
@@ -360,7 +360,7 @@ void RemoteTabletNode::DoScheduleRpc(RpcSchedule* rpc_schedule) {
         table_name = read_rpc->request->tablet_name();
         DoReadTablet(read_rpc->controller, read_rpc->start_micros,
                      read_rpc->request, read_rpc->response,
-                     read_rpc->done,read_rpc->timer);
+                     read_rpc->done, read_rpc->timer);
     } break;
     case RPC_SCAN: {
         ScanRpc* scan_rpc = (ScanRpc*)rpc;

--- a/src/tabletnode/tabletnode_sysinfo.cc
+++ b/src/tabletnode/tabletnode_sysinfo.cc
@@ -322,10 +322,8 @@ static int GetCpuCount() {
 // irix_on == 0 --> irix mode off
 //
 // return this process's the percentage of CPU usage ( %CPU ).
-// the number of digits after decimal point is UNCERTAIN.
-//   e.g. this function would return 19.12613, 42.0 or other number.
 //
-// NOTE: the first time call this function would get a "wrong" %CPU.
+// NOTE: the first time call this function would get 0 as result.
 static float GetCpuUsage(int is_irix_on) {
     static int cpu_count = 1; // assume cpu count is not variable when process is running
     static unsigned long hertz = 0;
@@ -355,9 +353,16 @@ static float GetCpuUsage(int is_irix_on) {
     float u = (newtick - (float)oldtick) * frame_etscale;
     oldtick = newtick;
 
-    if (u > 99.9f) {
-        u = 99.9;
+    const float MAX_CPU_USAGE = 99.9f;
+    if (u > MAX_CPU_USAGE ) {
+        u = MAX_CPU_USAGE;
     }
+    
+    // rounding cpu usage to 1 decimal places
+    const int USAGE_STR_MAX_LEN = 5;
+    char usage_str[USAGE_STR_MAX_LEN];
+    sprintf(usage_str, "%.1f\n", u);
+    sscanf(usage_str, "%f", &u);
     return u;
 }
 

--- a/src/tera_flags.cc
+++ b/src/tera_flags.cc
@@ -98,7 +98,7 @@ DEFINE_int64(tera_master_merge_timer_period, 180, "the actived time (in sec) for
 
 DEFINE_int32(tera_master_max_split_concurrency, 1, "the max concurrency of tabletnode for split tablet");
 DEFINE_int32(tera_master_max_load_concurrency, 5, "the max concurrency of tabletnode for load tablet");
-DEFINE_int32(tera_master_max_unload_concurrency, 5, "the max concurrency of tabletnode for unload tablet");
+DEFINE_int32(tera_master_max_unload_concurrency, 30, "the max concurrency of tabletnode for unload tablet");
 DEFINE_int32(tera_master_load_interval, 300, "the delay interval (in sec) for load tablet");
 DEFINE_int32(tera_master_load_balance_period, 10000, "the period (in ms) for load balance policy execute");
 DEFINE_bool(tera_master_load_balance_table_grained, true, "whether the load balance policy only consider the specified table");

--- a/src/tera_flags.cc
+++ b/src/tera_flags.cc
@@ -98,6 +98,7 @@ DEFINE_int64(tera_master_merge_timer_period, 180, "the actived time (in sec) for
 
 DEFINE_int32(tera_master_max_split_concurrency, 1, "the max concurrency of tabletnode for split tablet");
 DEFINE_int32(tera_master_max_load_concurrency, 5, "the max concurrency of tabletnode for load tablet");
+DEFINE_int32(tera_master_max_unload_concurrency, 5, "the max concurrency of tabletnode for unload tablet");
 DEFINE_int32(tera_master_load_interval, 300, "the delay interval (in sec) for load tablet");
 DEFINE_int32(tera_master_load_balance_period, 10000, "the period (in ms) for load balance policy execute");
 DEFINE_bool(tera_master_load_balance_table_grained, true, "whether the load balance policy only consider the specified table");


### PR DESCRIPTION
**新的并发控制策略仅在 load 中实现，先不要看unload/split/merge部分**

队列中不再是简单的tablet，而是用boost::bind打包好的task.

PS：别看其它部分啊，很多调试信息、遗留代码。。。看看 **load** 部分就好，思路ok我就把unload/split/merge的并发控制迁移过来了。