### PR TITLE
master task concurrency control with priority

### DIFF
--- a/src/io/utils_leveldb.cc
+++ b/src/io/utils_leveldb.cc
@@ -25,6 +25,8 @@ DECLARE_string(tera_leveldb_env_nfs_mountpoint);
 DECLARE_string(tera_leveldb_env_nfs_conf_path);
 DECLARE_string(tera_leveldb_env_hdfs2_nameservice_list);
 DECLARE_string(tera_tabletnode_path_prefix);
+DECLARE_string(tera_dfs_so_path);
+DECLARE_string(tera_dfs_conf);
 
 namespace tera {
 namespace io {
@@ -42,9 +44,13 @@ void InitDfsEnv() {
     } else if (FLAGS_tera_leveldb_env_dfs_type == "hdfs2") {
         LOG(INFO) << "init hdfs2 system";
         leveldb::InitHdfs2Env(FLAGS_tera_leveldb_env_hdfs2_nameservice_list);
-    } else {
+    } else if (FLAGS_tera_leveldb_env_dfs_type == "hdfs") {
         LOG(INFO) << "init hdfs system";
         leveldb::InitHdfsEnv();
+    } else {
+        LOG(INFO) << "Init dfs system: " << FLAGS_tera_dfs_so_path << "("
+                  << FLAGS_tera_dfs_conf << ")";
+        leveldb::InitDfsEnv(FLAGS_tera_dfs_so_path, FLAGS_tera_dfs_conf);
     }
 }
 

--- a/src/leveldb/bench/tera_bench.cc
+++ b/src/leveldb/bench/tera_bench.cc
@@ -66,26 +66,14 @@ class RandomGenerator {
   }
 
   Slice Generate(int len) {
-    if (pos_ + len > data_.size()) {
+    if (pos_ + len > static_cast<int>(data_.size())) {
       pos_ = 0;
-      assert(len < data_.size());
+      assert(len < static_cast<int>(data_.size()));
     }
     pos_ += len;
     return Slice(data_.data() + pos_ - len, len);
   }
 };
-
-static Slice TrimSpace(Slice s) {
-  int start = 0;
-  while (start < s.size() && isspace(s[start])) {
-    start++;
-  }
-  int limit = s.size();
-  while (limit > start && isspace(s[limit-1])) {
-    limit--;
-  }
-  return Slice(s.data() + start, limit - start);
-}
 
 }  // namespace
 

--- a/src/leveldb/db/db_bench.cc
+++ b/src/leveldb/db/db_bench.cc
@@ -155,9 +155,9 @@ class RandomGenerator {
   }
 
   Slice Generate(int len) {
-    if (pos_ + len > data_.size()) {
+    if (pos_ + len > static_cast<int>(data_.size())) {
       pos_ = 0;
-      assert(len < data_.size());
+      assert(len < static_cast<int>(data_.size()));
     }
     pos_ += len;
     return Slice(data_.data() + pos_ - len, len);
@@ -165,11 +165,11 @@ class RandomGenerator {
 };
 
 static Slice TrimSpace(Slice s) {
-  int start = 0;
+  uint32_t start = 0;
   while (start < s.size() && isspace(s[start])) {
     start++;
   }
-  int limit = s.size();
+  uint32_t limit = s.size();
   while (limit > start && isspace(s[limit-1])) {
     limit--;
   }
@@ -425,7 +425,7 @@ class Benchmark {
     heap_counter_(0) {
     std::vector<std::string> files;
     Env::Default()->GetChildren(FLAGS_db, &files);
-    for (int i = 0; i < files.size(); i++) {
+    for (uint32_t i = 0; i < files.size(); i++) {
       if (Slice(files[i]).starts_with("heap-")) {
         Env::Default()->DeleteFile(std::string(FLAGS_db) + "/" + files[i]);
       }

--- a/src/leveldb/db/import_main.cc
+++ b/src/leveldb/db/import_main.cc
@@ -45,7 +45,7 @@ bool SaveKVToDB(void* arg, const char* buffer, ssize_t size) {
 //
 bool SaveSeqKVToDB(void* arg, const char* buffer, ssize_t size) {
     DB* db = reinterpret_cast<DB*>(arg);
-    if (size <= sizeof(int64_t) * 2) {
+    if (size <= static_cast<ssize_t>(sizeof(int64_t)) * 2) {
         return false;
     }
     Slice input(buffer, size);

--- a/src/leveldb/include/leveldb/dfs.h
+++ b/src/leveldb/include/leveldb/dfs.h
@@ -75,7 +75,7 @@ private:
 /// Dfs creator type.
 typedef Dfs* (*DfsCreator)(const char*);
 
-/// Impliment a dfs wrapper like this:
+/// Implement your own dfs like this:
 /// class MyDfsFile : public DfsFile {
 ///     ...
 /// };
@@ -85,7 +85,9 @@ typedef Dfs* (*DfsCreator)(const char*);
 ///
 /// extern "C" {
 /// Dfs* NewDfs(const char* conf) {
-///     return new MyDfs(conf);
+///     Dfs* dfs= new MyDfs;
+///     ...
+///     return dfs;
 /// }
 /// }
 

--- a/src/leveldb/include/leveldb/dfs.h
+++ b/src/leveldb/include/leveldb/dfs.h
@@ -6,6 +6,8 @@
 #define  TERA_LEVELDB_DFS_H_
 
 #include <stdint.h>
+#include <string>
+#include <vector>
 
 namespace leveldb {
 
@@ -61,12 +63,26 @@ public:
     virtual int32_t Copy(const std::string& from, const std::string& to) = 0;
     /// Returns 0 on success.
     virtual int32_t ListDirectory(const std::string& path, std::vector<std::string>* result) = 0;
-    /// Return DfsFile handler on success, NULL on error.
+    /// Returns DfsFile handler on success, NULL on error.
     virtual DfsFile* OpenFile(const std::string& filename, int32_t flags) = 0;
+    /// Returns Dfs handler on success, NULL on error.
+    static Dfs* NewDfs(const std::string& so_path, const std::string& conf); 
 private:
     Dfs(const Dfs&);
     void operator=(const Dfs&);
 };
+
+/// Dfs creator type.
+/// Impliment a dfs wrapper like this:
+/// class MyDfs : public Dfs {
+///     ...
+/// };
+///
+/// extern "C" {
+/// Dfs* NewDfs(const char* conf) {
+///     return new MyDfs(conf);
+/// }
+typedef Dfs* (*DfsCreator)(const char*);
 
 } // namespace leveldb
 #endif  //TERA_LEVELDB_DFS_H_

--- a/src/leveldb/include/leveldb/dfs.h
+++ b/src/leveldb/include/leveldb/dfs.h
@@ -85,7 +85,7 @@ typedef Dfs* (*DfsCreator)(const char*);
 ///
 /// extern "C" {
 /// Dfs* NewDfs(const char* conf) {
-///     Dfs* dfs= new MyDfs;
+///     Dfs* dfs= new MyDfs();
 ///     ...
 ///     return dfs;
 /// }

--- a/src/leveldb/include/leveldb/dfs.h
+++ b/src/leveldb/include/leveldb/dfs.h
@@ -73,7 +73,12 @@ private:
 };
 
 /// Dfs creator type.
+typedef Dfs* (*DfsCreator)(const char*);
+
 /// Impliment a dfs wrapper like this:
+/// class MyDfsFile : public DfsFile {
+///     ...
+/// };
 /// class MyDfs : public Dfs {
 ///     ...
 /// };
@@ -82,7 +87,7 @@ private:
 /// Dfs* NewDfs(const char* conf) {
 ///     return new MyDfs(conf);
 /// }
-typedef Dfs* (*DfsCreator)(const char*);
+/// }
 
 } // namespace leveldb
 #endif  //TERA_LEVELDB_DFS_H_

--- a/src/leveldb/include/leveldb/env_dfs.h
+++ b/src/leveldb/include/leveldb/env_dfs.h
@@ -67,7 +67,8 @@ private:
     Dfs* hdfs_;
 };
 
-/// init env
+/// Init dfs env
+void InitDfsEnv(const std::string& so_path, const std::string& conf);
 void InitHdfsEnv();
 void InitHdfs2Env(const std::string& namenode_list);
 void InitNfsEnv(const std::string& mountpoint,

--- a/src/leveldb/util/dfs.cc
+++ b/src/leveldb/util/dfs.cc
@@ -1,0 +1,37 @@
+// Copyright (c) 2015, Baidu.com, Inc. All Rights Reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+// Author: yanshiguang02@baidu.com
+
+#include "leveldb/dfs.h"
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <string>
+
+namespace leveldb {
+
+Dfs* Dfs::NewDfs(const std::string& so_path, const std::string& conf) {
+    dlerror();
+    void* handle = dlopen(so_path.c_str(), RTLD_NOW);
+    if (handle == NULL) {
+        fprintf(stderr, "Open %s fail\n", so_path.c_str());
+        return NULL;
+    }
+
+    dlerror();
+
+    DfsCreator creator = (DfsCreator)dlsym(handle, "NewDfs");
+    const char* err = dlerror();
+    if (err != NULL) {
+        fprintf(stderr, "Load NewDfs from %s fail: %s\n", so_path.c_str(), err);
+        return NULL;
+    }
+
+    return (*creator)(conf.c_str());
+}
+
+}
+
+/* vim: set expandtab ts=4 sw=4 sts=4 tw=100: */

--- a/src/leveldb/util/env_dfs.cc
+++ b/src/leveldb/util/env_dfs.cc
@@ -441,6 +441,16 @@ static bool inited = false;
 static port::Mutex mutex;
 static Env* dfs_env;
 
+void InitDFS(const std::string& so_path, const std::string& conf) {
+    MutexLock l(&mutex);
+    if (inited) {
+        return;
+    }
+    Dfs* dfs = Dfs::NewDfs(so_path, conf.c_str());
+    dfs_env = new DfsEnv(dfs);
+    inited = true;
+}
+
 void InitHdfsEnv()
 {
     MutexLock l(&mutex);

--- a/src/leveldb/util/env_dfs.cc
+++ b/src/leveldb/util/env_dfs.cc
@@ -446,7 +446,7 @@ void InitDfsEnv(const std::string& so_path, const std::string& conf) {
     if (inited) {
         return;
     }
-    Dfs* dfs = Dfs::NewDfs(so_path, conf.c_str());
+    Dfs* dfs = Dfs::NewDfs(so_path, conf);
     if (dfs == NULL) {
         abort();
     }

--- a/src/leveldb/util/env_dfs.cc
+++ b/src/leveldb/util/env_dfs.cc
@@ -441,12 +441,15 @@ static bool inited = false;
 static port::Mutex mutex;
 static Env* dfs_env;
 
-void InitDFS(const std::string& so_path, const std::string& conf) {
+void InitDfsEnv(const std::string& so_path, const std::string& conf) {
     MutexLock l(&mutex);
     if (inited) {
         return;
     }
     Dfs* dfs = Dfs::NewDfs(so_path, conf.c_str());
+    if (dfs == NULL) {
+        abort();
+    }
     dfs_env = new DfsEnv(dfs);
     inited = true;
 }

--- a/src/master/master_impl.cc
+++ b/src/master/master_impl.cc
@@ -6,17 +6,18 @@
 
 #include <algorithm>
 #include <boost/bind.hpp>
+#include <boost/function.hpp>
 
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <gperftools/malloc_extension.h>
-
 
 #include "db/filename.h"
 #include "io/io_utils.h"
 #include "io/utils_leveldb.h"
 #include "leveldb/status.h"
 #include "master/master_zk_adapter.h"
+#include "master/task_spatula.h"
 #include "master/workload_scheduler.h"
 #include "proto/kv_helper.h"
 #include "proto/master_client.h"
@@ -307,7 +308,7 @@ void MasterImpl::RestoreUserTablet(const std::vector<TabletMeta>& report_meta_li
             UnloadClosure* done =
                 NewClosure(this, &MasterImpl::UnloadTabletCallback,
                            unknown_tablet, FLAGS_tera_master_impl_retry_times);
-            UnloadTabletAsync(unknown_tablet, done);
+            TryUnloadTablet(unknown_tablet, done, kTaskUnload);
         } else {
             tablet->SetStatus(kTableReady);
             tablet->SetSize(size);
@@ -338,9 +339,9 @@ void MasterImpl::RestoreUserTablet(const std::vector<TabletMeta>& report_meta_li
         if (!server_addr.empty()
             && m_tabletnode_manager->FindTabletNode(server_addr, &node)
             && node->m_state == kReady) {
-            TryLoadTablet(tablet, server_addr);
+            TryLoadTablet(tablet, kTaskLoad, server_addr);
         } else if (server_addr.empty()) {
-            TryLoadTablet(tablet);
+            TryLoadTablet(tablet, kTaskLoad);
         } else {
             dead_node_tablet_list.push_back(tablet);
         }
@@ -358,7 +359,7 @@ void MasterImpl::RestoreUserTablet(const std::vector<TabletMeta>& report_meta_li
     it = dead_node_tablet_list.begin();
     for (; it != dead_node_tablet_list.end(); ++it) {
         TabletPtr tablet = *it;
-        TryLoadTablet(tablet);
+        TryLoadTablet(tablet, kTaskLoad);
     }
     SetMasterStatus(kIsRunning);
     m_zk_adapter->UnmarkSafeMode();
@@ -378,7 +379,7 @@ void MasterImpl::LoadAllOffLineTablet() {
         const std::string& path = tablet->GetPath();
         if (tablet->GetStatus() == kTableOffLine) {
             LOG(INFO) << "load offline tablet: " << path;
-            TryLoadTablet(tablet);
+            TryLoadTablet(tablet, kTaskLoad);
         }
     }
 }
@@ -608,12 +609,15 @@ void MasterImpl::DisableTable(const DisableTableRequest* request,
             UnloadClosure* done =
                 NewClosure(this, &MasterImpl::UnloadTabletCallback, tablet,
                            FLAGS_tera_master_impl_retry_times);
-            UnloadTabletAsync(tablet, done);
+            TryUnloadTablet(tablet, done, kTaskUnloadForDisable);
         } else if (tablet->SetStatusIf(kTabletDisable, kTableOffLine, kTableDisable)) {
             WriteClosure* closure =
                 NewClosure(this, &MasterImpl::UpdateTabletRecordCallback, tablet,
                            FLAGS_tera_master_meta_retry_times);
             WriteMetaTableAsync(tablet, false, closure);
+        } else {
+            LOG(ERROR) << "[disable] tablet status: " << StatusCodeToString(tablet->GetStatus())
+                       << ", table status: " << StatusCodeToString(table->GetStatus());
         }
     }
 }
@@ -660,7 +664,7 @@ void MasterImpl::EnableTable(const EnableTableRequest* request,
     for (uint32_t i = 0; i < tablet_meta_list.size(); ++i) {
         TabletPtr tablet = tablet_meta_list[i];
         if (tablet->SetStatusIf(kTableOffLine, kTabletDisable, kTableEnable)) {
-            TryLoadTablet(tablet, tablet->GetServerAddr());
+            TryLoadTablet(tablet, kTaskLoad, tablet->GetServerAddr());
         }
     }
 }
@@ -953,7 +957,7 @@ void MasterImpl::TabletCmdCtrl(const CmdCtrlRequest* request,
         if (request->arg_list_size() == 3) {
             expect_server_addr = request->arg_list(2);
         }
-        TryMoveTablet(tablet, expect_server_addr);
+        TryMoveTablet(tablet, kTaskUnloadForBalance, expect_server_addr);
         response->set_status(kMasterOk);
     } else if (request->arg_list(0) == "split") {
         if (request->arg_list_size() > 3) {
@@ -965,7 +969,7 @@ void MasterImpl::TabletCmdCtrl(const CmdCtrlRequest* request,
             split_key = request->arg_list(2);
             LOG(INFO) << "ignore user specified split key: not support";
         }
-        TrySplitTablet(tablet);
+        TrySplitTablet(tablet, kTaskSplit);
         response->set_status(kMasterOk);
     } else {
         response->set_status(kInvalidArgument);
@@ -1241,7 +1245,7 @@ void MasterImpl::TabletNodeLoadBalance(const std::string& tabletnode_addr,
         if (tablet->GetSchema().has_split_size() && tablet->GetSchema().split_size() > 0) {
             split_size = tablet->GetSchema().split_size();
         }
-        int64_t merge_size = FLAGS_tera_master_merge_tablet_size;
+        int64_t merge_size = 0;
         if (tablet->GetSchema().has_merge_size() && tablet->GetSchema().merge_size() > 0) {
             merge_size = tablet->GetSchema().merge_size();
         }
@@ -1249,11 +1253,11 @@ void MasterImpl::TabletNodeLoadBalance(const std::string& tabletnode_addr,
             // tablet size is error, skip it
             continue;
         } else if (tablet->GetDataSize() > (split_size << 20)) {
-            TrySplitTablet(tablet);
+            TrySplitTablet(tablet, kTaskSplit);
             any_tablet_split = true;
             continue;
         } else if (tablet->GetDataSize() < (merge_size << 20)) {
-            TryMergeTablet(tablet);
+            TryMergeTablet(tablet, kTaskUnloadForBalance);
             continue;
         }
         if (tablet->GetStatus() == kTableReady) {
@@ -1275,7 +1279,7 @@ void MasterImpl::TabletNodeLoadBalance(const std::string& tabletnode_addr,
                                                  &expect_server_addr)
         && m_tabletnode_manager->ShouldMoveData(tabletnode_addr, expect_server_addr,
                                                 table_name, smallest_tablet_size)) {
-        TryMoveTablet(*smallest_tablet_it, expect_server_addr);
+        TryMoveTablet(*smallest_tablet_it, kTaskUnloadForBalance, expect_server_addr);
     }
 }
 
@@ -1476,7 +1480,7 @@ void MasterImpl::TabletNodeRecoveryCallback(std::string addr,
             UnloadClosure* done =
                 NewClosure(this, &MasterImpl::UnloadTabletCallback, unload_tablet,
                            FLAGS_tera_master_impl_retry_times);
-            UnloadTabletAsync(unload_tablet, done);
+            TryUnloadTablet(unload_tablet, done, kTaskUnload);
         } else if (tablet->SetStatusIf(kTableReady, kTabletPending)
             || tablet->SetStatusIf(kTableReady, kTableOffLine)) {
             tablet->SetSize(meta.table_size());
@@ -1528,7 +1532,7 @@ void MasterImpl::TabletNodeRecoveryCallback(std::string addr,
                                      &meta_tablet)
         && meta_tablet->GetStatus() == kTableOffLine) {
         LOG(INFO) << "try load meta tablet on new ts: " << addr;
-        TryLoadTablet(meta_tablet);
+        TryLoadTablet(meta_tablet, kTaskLoad);
     }
 
     // load the rest offline tablets
@@ -1540,7 +1544,7 @@ void MasterImpl::TabletNodeRecoveryCallback(std::string addr,
         }
         if (tablet->GetStatus() == kTableOffLine) {
             LOG(INFO) << "try load, " << tablet;
-            TryLoadTablet(tablet, addr);
+            TryLoadTablet(tablet, kTaskLoad, addr);
         }
     }
 
@@ -1589,7 +1593,7 @@ void MasterImpl::DeleteTabletNode(const std::string& tabletnode_addr) {
         if (tablet->GetTableName() == FLAGS_tera_master_meta_table_name
             && tablet->GetStatus() == kTableOffLine) {
             LOG(INFO) << "try move meta tablet";
-            TryLoadTablet(tablet);
+            TryLoadTablet(tablet, kTaskLoad);
         }
     }
 
@@ -1633,7 +1637,7 @@ void MasterImpl::TryMovePendingTablet(TabletPtr tablet) {
     if (GetMasterStatus() == kIsRunning
         && tablet->GetStatus() == kTableOffLine) {
         LOG(INFO) << "try move, " << tablet;
-        TryLoadTablet(tablet);
+        TryLoadTablet(tablet, kTaskLoad);
     }
 }
 
@@ -1720,7 +1724,7 @@ void MasterImpl::LoadAllOffLineTablets() {
         TabletPtr tablet = *it;
         if (tablet->GetStatus() == kTableOffLine) {
             LOG(INFO) << "try move, " << tablet;
-            TryLoadTablet(tablet);
+            TryLoadTablet(tablet, kTaskLoad);
         }
     }
 }
@@ -1741,7 +1745,7 @@ void MasterImpl::LoadAllDeadNodeTablets() {
             continue;
         }
         LOG(INFO) << "try move, " << tablet;
-        TryLoadTablet(tablet);
+        TryLoadTablet(tablet, kTaskLoad);
     }
 }
 
@@ -1751,7 +1755,7 @@ void MasterImpl::MoveOffLineTablets(const std::vector<TabletPtr>& tablet_list) {
         TabletPtr tablet = *it;
         if (tablet->GetStatus() == kTableOffLine) {
             LOG(INFO) << "try move, " << tablet;
-            TryLoadTablet(tablet);
+            TryLoadTablet(tablet, kTaskLoad);
         }
     }
 }
@@ -1920,7 +1924,7 @@ void MasterImpl::LoadTabletCallback(TabletPtr tablet, int32_t retry,
         LOG(ERROR) << "fail to load tablet: server down, " << tablet;
         tablet->SetStatusIf(kTableOffLine, kTableOnLoad);
         ProcessOffLineTablet(tablet);
-        TryLoadTablet(tablet, server_addr);
+        TryLoadTablet(tablet, kTaskLoad, server_addr);
         return;
     }
 
@@ -1929,7 +1933,7 @@ void MasterImpl::LoadTabletCallback(TabletPtr tablet, int32_t retry,
         LOG(ERROR) << "fail to load tablet: server restart, " << tablet;
         tablet->SetStatusIf(kTableOffLine, kTableOnLoad);
         ProcessOffLineTablet(tablet);
-        TryLoadTablet(tablet, server_addr);
+        TryLoadTablet(tablet, kTaskLoad, server_addr);
         return;
     }
 
@@ -1945,20 +1949,12 @@ void MasterImpl::LoadTabletCallback(TabletPtr tablet, int32_t retry,
         }
         ProcessReadyTablet(tablet);
 
-        // load next
-        node->FinishLoad(tablet);
-        TabletPtr next_tablet;
-        while (node->LoadNextWaitTablet(&next_tablet)) {
-            if (next_tablet->SetAddrAndStatusIf(server_addr, kTableOnLoad, kTableOffLine)) {
-                next_tablet->SetServerId(node->m_uuid);
-                WriteClosure* done =
-                    NewClosure(this, &MasterImpl::UpdateMetaForLoadCallback,
-                               next_tablet, FLAGS_tera_master_meta_retry_times);
-                WriteMetaTableAsync(next_tablet, false, done);
-                break;
-            }
-            node->FinishLoad(next_tablet);
+        // load rest tablets
+        if (tablet->GetTableName() != FLAGS_tera_master_meta_table_name) {
+            // concurrency control doesn't cover meta table 
+            node->m_load_spatula.FinishTask();
         }
+        node->m_load_spatula.TryDrain();
         return;
     }
 
@@ -1979,7 +1975,7 @@ void MasterImpl::LoadTabletCallback(TabletPtr tablet, int32_t retry,
             UnloadClosure* done =
                 NewClosure(this, &MasterImpl::UnloadTabletCallback, tablet,
                            FLAGS_tera_master_impl_retry_times);
-            UnloadTabletAsync(tablet, done);
+            TryUnloadTablet(tablet, done, kTaskUnload);
             return;
         }
         if (retry > FLAGS_tera_master_impl_retry_times && retry % 10 == 0) {
@@ -1990,7 +1986,7 @@ void MasterImpl::LoadTabletCallback(TabletPtr tablet, int32_t retry,
         UnloadClosure* done =
             NewClosure(this, &MasterImpl::UnloadTabletCallback, tablet,
                        FLAGS_tera_master_impl_retry_times);
-        UnloadTabletAsync(tablet, done);
+        TryUnloadTablet(tablet, done, kTaskUnload);
         return;
     }
 
@@ -2064,10 +2060,10 @@ void MasterImpl::UnloadTabletCallback(TabletPtr tablet, int32_t retry,
         LOG(ERROR) << "abort UnloadTablet: server down, " << tablet;
         if (tablet->SetAddrAndStatusIf("", kTableOffLine, kTableUnLoading)) {
             ProcessOffLineTablet(tablet);
-            TryLoadTablet(tablet);
+            TryLoadTablet(tablet, kTaskLoad);
         } else if (tablet->SetAddrAndStatusIf("", kTableOffLine, kTableOnLoad)) {
             ProcessOffLineTablet(tablet);
-            TryLoadTablet(tablet);
+            TryLoadTablet(tablet, kTaskLoad);
         } else {
             CHECK(tablet->GetStatus() == kTableOnSplit);
             ScanClosure* done =
@@ -2083,36 +2079,28 @@ void MasterImpl::UnloadTabletCallback(TabletPtr tablet, int32_t retry,
         LOG(ERROR) << "abort UnloadTablet: server restart, " << tablet;
         tablet->SetStatusIf(kTableOffLine, kTableOnLoad);
         ProcessOffLineTablet(tablet);
-        TryLoadTablet(tablet, server_addr);
+        TryLoadTablet(tablet, kTaskLoad, server_addr);
         return;
     }
 
     // success
     if (!failed && (status == kTabletNodeOk || status == kKeyNotInRange)) {
-        LOG(INFO) << "unload tablet success, " << tablet;
+        LOG(INFO) << "unload tablet success, " << tablet << ", at: " << server_addr;
+        // unload rest tablets
+        node->m_unload_spatula.FinishTask();
+        node->m_unload_spatula.TryDrain();
         if (tablet->SetStatusIf(kTableOffLine, kTableUnLoading)) {
             ProcessOffLineTablet(tablet);
             // unload success, try load
-            TryLoadTablet(tablet);
+            TryLoadTablet(tablet, kTaskLoad);
         } else if (tablet->SetStatusIf(kTableOffLine, kTableOnLoad)) {
             ProcessOffLineTablet(tablet);
             // load fail but unload success, try reload
-            TryLoadTablet(tablet);
+            TryLoadTablet(tablet, kTaskLoad);
 
-            // load next tablet
-            node->FinishLoad(tablet);
-            TabletPtr next_tablet;
-            while (node->LoadNextWaitTablet(&next_tablet)) {
-                if (next_tablet->SetAddrAndStatusIf(server_addr, kTableOnLoad, kTableOffLine)) {
-                    next_tablet->SetServerId(node->m_uuid);
-                    WriteClosure* done =
-                        NewClosure(this, &MasterImpl::UpdateMetaForLoadCallback,
-                                   next_tablet, FLAGS_tera_master_meta_retry_times);
-                    WriteMetaTableAsync(next_tablet, false, done);
-                    break;
-                }
-                node->FinishLoad(next_tablet);
-            }
+            // load rest tablets
+            node->m_load_spatula.FinishTask();
+            node->m_load_spatula.TryDrain();
         } else {
             CHECK(tablet->GetStatus() == kTableOnSplit);
             // don't know split result, scan meta to determine the result
@@ -2120,22 +2108,9 @@ void MasterImpl::UnloadTabletCallback(TabletPtr tablet, int32_t retry,
                 NewClosure(this, &MasterImpl::ScanMetaCallbackForSplit, tablet);
             ScanMetaTableAsync(tablet->GetTableName(), tablet->GetKeyStart(),
                                tablet->GetKeyEnd(), done);
-
-            // split next tablet
-            TabletNodePtr node;
-            if (m_tabletnode_manager->FindTabletNode(server_addr, &node)
-                && node->m_uuid == tablet->GetServerId()) {
-                node->FinishSplit(tablet);
-                TabletPtr next_tablet;
-                while (node->SplitNextWaitTablet(&next_tablet)) {
-                    if (next_tablet->SetStatusIf(kTableOnSplit, kTableReady)) {
-                        next_tablet->SetServerId(node->m_uuid);
-                        SplitTabletAsync(next_tablet);
-                        break;
-                    }
-                    node->FinishSplit(next_tablet);
-                }
-            }
+            // split rest tablets
+            node->m_split_spatula.FinishTask();
+            node->m_split_spatula.TryDrain();
         }
         return;
     }
@@ -2784,7 +2759,7 @@ void MasterImpl::SplitTabletCallback(TabletPtr tablet,
         UnloadClosure* done =
             NewClosure(this, &MasterImpl::UnloadTabletCallback, tablet,
                        FLAGS_tera_master_impl_retry_times);
-        UnloadTabletAsync(tablet, done);
+        TryUnloadTablet(tablet, done, kTaskUnload);
         return;
     }
 
@@ -2808,16 +2783,8 @@ void MasterImpl::SplitTabletCallback(TabletPtr tablet,
     TabletNodePtr node;
     if (m_tabletnode_manager->FindTabletNode(server_addr, &node)
         && node->m_uuid == tablet->GetServerId()) {
-        node->FinishSplit(tablet);
-        TabletPtr next_tablet;
-        while (node->SplitNextWaitTablet(&next_tablet)) {
-            if (next_tablet->SetStatusIf(kTableOnSplit, kTableReady)) {
-                next_tablet->SetServerId(node->m_uuid);
-                SplitTabletAsync(next_tablet);
-                break;
-            }
-            node->FinishSplit(next_tablet);
-        }
+        node->m_split_spatula.FinishTask();
+        node->m_split_spatula.TryDrain();
     }
 
     if (status == kTableNotSupport) {
@@ -2833,7 +2800,28 @@ void MasterImpl::SplitTabletCallback(TabletPtr tablet,
     }
 }
 
-void MasterImpl::TryLoadTablet(TabletPtr tablet, std::string server_addr) {
+void MasterImpl::TryUnloadTablet(TabletPtr tablet, UnloadClosure* done, int32_t priority) {
+    if (!tablet->IsBound()) {
+        return;
+    }
+    std::string server_addr = tablet->GetServerAddr();
+    TabletNodePtr node;
+    if (server_addr.empty()
+        || !m_tabletnode_manager->FindTabletNode(server_addr, &node)) {
+        LOG(ERROR) << "[unload] invalid tablet to unload";
+        return;
+    }
+
+    boost::function<void ()> task_func = 
+        boost::bind(&MasterImpl::UnloadTabletAsync, this, tablet, done);
+    ConcurrencyTask task(priority, task_func);
+    node->m_unload_spatula.EnQueueTask(task);
+    node->m_unload_spatula.TryDrain();
+    LOG(INFO) << "[unload] TryUnloadTablet: " << tablet->GetPath() 
+              << ", at: " << tablet->GetServerAddr();
+}
+
+void MasterImpl::TryLoadTablet(TabletPtr tablet, int32_t priority, std::string server_addr) {
     if (!tablet->IsBound()) {
         return;
     }
@@ -2914,14 +2902,6 @@ void MasterImpl::TryLoadTablet(TabletPtr tablet, std::string server_addr) {
         return;
     }
 
-    // other tables may wait in a queue
-    if (!node->TryLoad(tablet)) {
-        tablet->SetAddrIf(server_addr, kTableOffLine);
-        LOG(INFO) << "delay load table " << tablet->GetPath()
-            << ", too many tablets are loading on server: "
-            << server_addr;
-        return;
-    }
     if (!tablet->GetExpectServerAddr().empty()) {
         node->DoneMoveIn();
         tablet->SetExpectServerAddr("");
@@ -2930,31 +2910,14 @@ void MasterImpl::TryLoadTablet(TabletPtr tablet, std::string server_addr) {
     // abort if status switch to offline (server down / disable)
     if (!tablet->SetAddrAndStatusIf(server_addr, kTableOnLoad, kTableOffLine)) {
         LOG(ERROR) << "error state, abort load tablet, " << tablet;
-        node->FinishLoad(tablet);
-        TabletPtr next_tablet;
-        while (node->LoadNextWaitTablet(&next_tablet)) {
-            if (next_tablet->SetAddrAndStatusIf(server_addr, kTableOnLoad, kTableOffLine)) {
-                if (!next_tablet->GetExpectServerAddr().empty()) {
-                    node->DoneMoveIn();
-                    next_tablet->SetExpectServerAddr("");
-                }
-                next_tablet->SetServerId(node->m_uuid);
-                WriteClosure* done =
-                    NewClosure(this, &MasterImpl::UpdateMetaForLoadCallback,
-                               next_tablet, FLAGS_tera_master_meta_retry_times);
-                WriteMetaTableAsync(next_tablet, false, done);
-                break;
-            }
-            node->FinishLoad(next_tablet);
-        }
+        node->m_load_spatula.TryDrain();
         return;
     }
-
     // if server down here, let split callback take care of status switch
     tablet->SetServerId(node->m_uuid);
     WriteClosure* done =
         NewClosure(this, &MasterImpl::UpdateMetaForLoadCallback, tablet,
-                   FLAGS_tera_master_meta_retry_times);
+                   FLAGS_tera_master_meta_retry_times, priority);
     WriteMetaTableAsync(tablet, false, done);
     return;
 }
@@ -2967,7 +2930,7 @@ void MasterImpl::RetryLoadTablet(TabletPtr tablet, int32_t retry_times) {
             << ": server down, " << tablet;
         tablet->SetStatus(kTableOffLine);
         ProcessOffLineTablet(tablet);
-        TryLoadTablet(tablet, tablet->GetServerAddr());
+        TryLoadTablet(tablet, kTaskLoad, tablet->GetServerAddr());
         return;
     }
 
@@ -2976,13 +2939,20 @@ void MasterImpl::RetryLoadTablet(TabletPtr tablet, int32_t retry_times) {
         LOG(ERROR) << "retry LoadTablet: server restart, " << tablet;
         tablet->SetStatusIf(kTableOffLine, kTableOnLoad);
         ProcessOffLineTablet(tablet);
-        TryLoadTablet(tablet, tablet->GetServerAddr());
+        TryLoadTablet(tablet, kTaskLoad, tablet->GetServerAddr());
         return;
     }
 
     LoadClosure* done = NewClosure(this, &MasterImpl::LoadTabletCallback, tablet,
                                    retry_times);
-    LoadTabletAsync(tablet, done);
+
+    boost::function<void ()> task_func = 
+        boost::bind(&MasterImpl::LoadTabletAsync, this, tablet, done, 0);
+    ConcurrencyTask task(kTaskLoad, task_func);
+    node->m_load_spatula.EnQueueTask(task);
+    node->m_load_spatula.TryDrain();
+    LOG(INFO) << "[load] TryLoadTablet: " << tablet->GetPath() 
+              << ", at: " << tablet->GetServerAddr();
     return;
 }
 
@@ -2992,10 +2962,10 @@ void MasterImpl::RetryUnloadTablet(TabletPtr tablet, int32_t retry_times) {
         LOG(ERROR) << "abort UnloadTablet: server down, " << tablet;
         if (tablet->SetAddrAndStatusIf("", kTableOffLine, kTableUnLoading)) {
             ProcessOffLineTablet(tablet);
-            TryLoadTablet(tablet);
+            TryLoadTablet(tablet, kTaskLoad);
         } else if (tablet->SetAddrAndStatusIf("", kTableOffLine, kTableOnLoad)) {
             ProcessOffLineTablet(tablet);
-            TryLoadTablet(tablet);
+            TryLoadTablet(tablet, kTaskLoad);
         } else {
             CHECK(tablet->GetStatus() == kTableOnSplit);
             ScanClosure* done =
@@ -3008,10 +2978,10 @@ void MasterImpl::RetryUnloadTablet(TabletPtr tablet, int32_t retry_times) {
 
     UnloadClosure* done =
         NewClosure(this, &MasterImpl::UnloadTabletCallback, tablet, retry_times);
-    UnloadTabletAsync(tablet, done);
+    TryUnloadTablet(tablet, done, kTaskUnload);
 }
 
-bool MasterImpl::TrySplitTablet(TabletPtr tablet) {
+bool MasterImpl::TrySplitTablet(TabletPtr tablet, int32_t priority) {
     const std::string& server_addr = tablet->GetServerAddr();
 
     // abort if server down
@@ -3021,12 +2991,6 @@ bool MasterImpl::TrySplitTablet(TabletPtr tablet) {
         return false;
     }
 
-    // delay split
-    if (!node->TrySplit(tablet)) {
-        LOG(INFO) << "delay split table " << tablet->GetPath()
-            << ", too many tablets are splitting on server: " << server_addr;
-        return false;
-    }
     // abort if status switch to offline (server down / disable)
     if (!tablet->SetStatusIf(kTableOnSplit, kTableReady)) {
         LOG(ERROR) << "error state, abort split table " << tablet->GetPath();
@@ -3034,13 +2998,19 @@ bool MasterImpl::TrySplitTablet(TabletPtr tablet) {
     }
 
     // if server down here, let split callback take care of status switch
-    LOG(INFO) << "begin split table " << tablet->GetPath();
     tablet->SetServerId(node->m_uuid);
-    SplitTabletAsync(tablet);
+
+    boost::function<void ()> task_func = 
+        boost::bind(&MasterImpl::SplitTabletAsync, this, tablet);
+    ConcurrencyTask task(priority, task_func);
+    node->m_split_spatula.EnQueueTask(task);
+    node->m_split_spatula.TryDrain();
+    LOG(INFO) << "[split] TrySplitTablet " << tablet->GetPath() 
+              << ", at: " << tablet->GetServerAddr();
     return true;
 }
 
-bool MasterImpl::TryMergeTablet(TabletPtr tablet) {
+bool MasterImpl::TryMergeTablet(TabletPtr tablet, int32_t priority) {
     MutexLock lock(&m_tablet_mutex);
     const std::string& server_addr = tablet->GetServerAddr();
 
@@ -3066,28 +3036,57 @@ bool MasterImpl::TryMergeTablet(TabletPtr tablet) {
 
     LOG(INFO) << "[merge] begin merge tablet " << tablet->GetPath()
         << " and " << tablet2->GetPath();
-    MergeTabletAsync(tablet, tablet2);
+    MergeTabletAsync(tablet, tablet2, priority);
     return true;
 }
 
-void MasterImpl::MergeTabletAsync(TabletPtr tablet_p1, TabletPtr tablet_p2) {
+void MasterImpl::MergeTabletAsync(TabletPtr tablet_p1, TabletPtr tablet_p2, int32_t priority) {
+    std::string server_addr1 = tablet_p1->GetServerAddr();
+    std::string server_addr2 = tablet_p2->GetServerAddr();
+    TabletNodePtr node1;
+    TabletNodePtr node2;
+    if (server_addr1.empty() || server_addr2.empty()
+        || !m_tabletnode_manager->FindTabletNode(server_addr1, &node1)
+        || !m_tabletnode_manager->FindTabletNode(server_addr2, &node2)) {
+        LOG(ERROR) << "[merge] invalid tablet to unload";
+        return;
+    }
     if (tablet_p1->SetStatusIf(kTableUnLoading, kTableReady) &&
         tablet_p2->SetStatusIf(kTableUnLoading, kTableReady)) {
         Mutex* mu = new Mutex();
+        CHECK(mu != NULL);
+        // task for tablet_p1
         UnloadClosure* done1 =
             NewClosure(this, &MasterImpl::MergeTabletUnloadCallback, tablet_p1, tablet_p2, mu);
+        boost::function<void ()> task_func1 = 
+            boost::bind(&MasterImpl::UnloadTabletAsync, this, tablet_p1, done1);
+        ConcurrencyTask task1(priority, task_func1);
+        node1->m_unload_spatula.EnQueueTask(task1);
+
+        // task for tablet_p2
         UnloadClosure* done2 =
             NewClosure(this, &MasterImpl::MergeTabletUnloadCallback, tablet_p2, tablet_p1, mu);
-        UnloadTabletAsync(tablet_p1, done1);
-        UnloadTabletAsync(tablet_p2, done2);
+        boost::function<void ()> task_func2 = 
+            boost::bind(&MasterImpl::UnloadTabletAsync, this, tablet_p2, done2);
+        ConcurrencyTask task2(priority, task_func2);
+        node2->m_unload_spatula.EnQueueTask(task2);
+
+        node1->m_unload_spatula.TryDrain();
+        node2->m_unload_spatula.TryDrain();
+        LOG(INFO) << "[merge:unload] tablet " << tablet_p1->GetPath() 
+                  << ", at: " << tablet_p1->GetServerAddr();
+        LOG(INFO) << "[merge:unload] tablet " << tablet_p2->GetPath() 
+                  << ", at: " << tablet_p2->GetServerAddr();
     } else {
         LOG(WARNING) << "[merge] tablet not ready, merge failed and rollback.";
-        tablet_p1->SetStatusIf(kTableReady, kTableUnLoading);
-        tablet_p2->SetStatusIf(kTableReady, kTableUnLoading);
+        CHECK(tablet_p1->SetStatusIf(kTableReady, kTableUnLoading));
+        CHECK(tablet_p2->SetStatusIf(kTableReady, kTableUnLoading));
     }
 }
 
 void MasterImpl::MergeTabletAsyncPhase2(TabletPtr tablet_p1, TabletPtr tablet_p2) {
+    LOG(INFO) << "[merge] MergeTabletAsyncPhase2: "
+              << tablet_p1->GetPath() << " and " << tablet_p2->GetPath();
     leveldb::Env* env = io::LeveldbEnv();
     std::vector<std::string> children;
     std::string tablet_path = FLAGS_tera_tabletnode_path_prefix + tablet_p1->GetPath();
@@ -3111,6 +3110,7 @@ void MasterImpl::MergeTabletAsyncPhase2(TabletPtr tablet_p1, TabletPtr tablet_p2
         MergeTabletFailed(tablet_p1, tablet_p2);
         return;
     }
+    LOG(INFO) << "probe0";
 
     WriteTabletRequest* request = new WriteTabletRequest;
     WriteTabletResponse* response = new WriteTabletResponse;
@@ -3153,6 +3153,7 @@ void MasterImpl::MergeTabletAsyncPhase2(TabletPtr tablet_p1, TabletPtr tablet_p2
         LOG(FATAL) << "tablet range error, cannot be merged: "
             << tablet_p1 << ", " << tablet_p2;
     }
+    LOG(INFO) << "probe1";
     new_meta.set_status(kTableOffLine);
     // load new tablet on server which has larger parent tablet
     new_meta.set_server_addr(
@@ -3163,6 +3164,8 @@ void MasterImpl::MergeTabletAsyncPhase2(TabletPtr tablet_p1, TabletPtr tablet_p2
                                     tablet_p1->GetTable()->GetNextTabletNo());
     new_meta.set_path(new_path);
     new_meta.set_table_size(tablet_p1->GetDataSize() + tablet_p2->GetDataSize());
+
+    LOG(INFO) << "probe2";
 
     Tablet tablet_c(new_meta, tablet_p1->GetTable());
     tablet_c.ToMetaTableKeyValue(&packed_key, &packed_value);
@@ -3177,6 +3180,7 @@ void MasterImpl::MergeTabletAsyncPhase2(TabletPtr tablet_p1, TabletPtr tablet_p2
                    tablet_p1, tablet_p2, FLAGS_tera_master_meta_retry_times);
     tabletnode::TabletNodeClient meta_node_client(meta_addr);
     meta_node_client.WriteTablet(request, response, done);
+    LOG(INFO) << "probe3";
 }
 
 void MasterImpl::MergeTabletUnloadCallback(TabletPtr tablet, TabletPtr tablet2, Mutex* mutex,
@@ -3198,14 +3202,14 @@ void MasterImpl::MergeTabletUnloadCallback(TabletPtr tablet, TabletPtr tablet2, 
         LOG(ERROR) << "[merge] abort UnloadTablet: server down, " << tablet;
         tablet->SetAddrAndStatusIf("", kTableOffLine, kTableUnLoading);
         ProcessOffLineTablet(tablet);
-        TryLoadTablet(tablet);
+        TryLoadTablet(tablet, kTaskLoad);
         if (tablet2->GetStatus() == kTableOnMerge) {
             LOG(WARNING) << "[merge] tablet2 unload succ, reload it: " << tablet2;
             mutex->Unlock();
             delete mutex;
             tablet2->SetStatusIf(kTableOffLine, kTableOnMerge);
             ProcessOffLineTablet(tablet2);
-            TryLoadTablet(tablet2);
+            TryLoadTablet(tablet2, kTaskLoad);
         } else if (tablet2->GetStatus() == kTableUnLoading) {
             LOG(WARNING) << "[merge] tablet2 still unloading: " << tablet2;
             mutex->Unlock();
@@ -3220,6 +3224,11 @@ void MasterImpl::MergeTabletUnloadCallback(TabletPtr tablet, TabletPtr tablet2, 
     // unload success
     if (!failed && (status == kTabletNodeOk || status == kKeyNotInRange)) {
         LOG(INFO) << "[merge] unload tablet success, " << tablet;
+
+        // unload rest tablets
+        node->m_unload_spatula.FinishTask();
+        node->m_unload_spatula.TryDrain();
+
         CHECK(tablet->SetStatusIf(kTableOnMerge, kTableUnLoading))
             << "[merge] tablet status not unloading";
         if (tablet2->GetStatus() == kTableOnMerge) {
@@ -3237,7 +3246,7 @@ void MasterImpl::MergeTabletUnloadCallback(TabletPtr tablet, TabletPtr tablet2, 
             delete mutex;
             tablet->SetStatusIf(kTableOffLine, kTableOnMerge);
             ProcessOffLineTablet(tablet);
-            TryLoadTablet(tablet);
+            TryLoadTablet(tablet, kTaskLoad);
         }
         return;
     }
@@ -3252,14 +3261,14 @@ void MasterImpl::MergeTabletUnloadCallback(TabletPtr tablet, TabletPtr tablet2, 
 
     tablet->SetStatusIf(kTableOffLine, kTableUnLoading);
     ProcessOffLineTablet(tablet);
-    TryLoadTablet(tablet);
+    TryLoadTablet(tablet, kTaskLoad);
     if (tablet2->GetStatus() == kTableOnMerge) {
         LOG(INFO) << "[merge] tablet2 unload succ, reload it: " << tablet2;
         mutex->Unlock();
         delete mutex;
         tablet2->SetStatusIf(kTableOffLine, kTableOnMerge);
         ProcessOffLineTablet(tablet2);
-        TryLoadTablet(tablet2);
+        TryLoadTablet(tablet2, kTaskLoad);
     } else if (tablet2->GetStatus() == kTableUnLoading) {
         // the other tablet have not unload, do nothing
         LOG(INFO) << "[merge] tablet2 still unloading: " << tablet2;
@@ -3329,7 +3338,7 @@ void MasterImpl::MergeTabletWriteMetaCallback(TabletMeta new_meta,
         m_tablet_manager->DeleteTablet(tablet_p1->GetTableName(), tablet_p1->GetKeyStart());
     }
     ProcessOffLineTablet(tablet_c);
-    TryLoadTablet(tablet_c);
+    TryLoadTablet(tablet_c, kTaskLoad);
     delete request;
     delete response;
     LOG(INFO) << "[merge] merge tablet finished, from [" << tablet_p1
@@ -3343,10 +3352,10 @@ void MasterImpl::MergeTabletFailed(TabletPtr tablet_p1, TabletPtr tablet_p2) {
         << tablet_p1 << ", " << tablet_p2;
     tablet_p1->SetStatusIf(kTableOffLine, kTableOnMerge);
     ProcessOffLineTablet(tablet_p1);
-    TryLoadTablet(tablet_p1);
+    TryLoadTablet(tablet_p1, kTaskLoad);
     tablet_p2->SetStatusIf(kTableOffLine, kTableOnMerge);
     ProcessOffLineTablet(tablet_p2);
-    TryLoadTablet(tablet_p2);
+    TryLoadTablet(tablet_p2, kTaskLoad);
 }
 
 void MasterImpl::WriteMetaTableAsync(TablePtr table, bool is_delete,
@@ -3484,7 +3493,7 @@ void MasterImpl::AddMetaCallback(TablePtr table,
     for (size_t i = 0; i < tablets.size(); i++) {
         if (tablets[i]->SetStatusIf(kTableOffLine, kTableNotInit)) {
             ProcessOffLineTablet(tablets[i]);
-            TryLoadTablet(tablets[i]);
+            TryLoadTablet(tablets[i], kTaskLoad);
         }
     }
 }
@@ -3642,6 +3651,7 @@ void MasterImpl::UpdateTabletRecordCallback(TabletPtr tablet, int32_t retry_time
 }
 
 void MasterImpl::UpdateMetaForLoadCallback(TabletPtr tablet, int32_t retry_times,
+                                           int32_t priority,
                                            WriteTabletRequest* request,
                                            WriteTabletResponse* response,
                                            bool failed, int error_code) {
@@ -3668,30 +3678,19 @@ void MasterImpl::UpdateMetaForLoadCallback(TabletPtr tablet, int32_t retry_times
             tablet->SetStatusIf(kTableOffLine, kTableOnLoad);
             ProcessOffLineTablet(tablet);
             // load fail, try reload
-            TryLoadTablet(tablet, server_addr);
+            TryLoadTablet(tablet, kTaskLoad, server_addr);
 
-            // load next tablet
+            // load rests tablets
             TabletNodePtr node;
             if (m_tabletnode_manager->FindTabletNode(server_addr, &node)
                 && node->m_uuid == tablet->GetServerId()) {
-                node->FinishLoad(tablet);
-                TabletPtr next_tablet;
-                while (node->LoadNextWaitTablet(&next_tablet)) {
-                    if (next_tablet->SetAddrAndStatusIf(server_addr, kTableOnLoad, kTableOffLine)) {
-                        next_tablet->SetServerId(node->m_uuid);
-                        WriteClosure* done =
-                            NewClosure(this, &MasterImpl::UpdateMetaForLoadCallback,
-                                       next_tablet, FLAGS_tera_master_meta_retry_times);
-                        WriteMetaTableAsync(next_tablet, false, done);
-                        break;
-                    }
-                    node->FinishLoad(next_tablet);
-                }
+                node->m_load_spatula.FinishTask();
+                node->m_load_spatula.TryDrain();
             }
         } else {
             WriteClosure* done =
                 NewClosure(this, &MasterImpl::UpdateMetaForLoadCallback,
-                           tablet, retry_times - 1);
+                           tablet, retry_times - 1, priority);
             SuspendMetaOperation(tablet, false, done);
         }
         return;
@@ -3701,7 +3700,19 @@ void MasterImpl::UpdateMetaForLoadCallback(TabletPtr tablet, int32_t retry_times
     // if server down here, let split callback take care of status switch
     LoadClosure* done = NewClosure(this, &MasterImpl::LoadTabletCallback ,
                                    tablet, 0);
-    LoadTabletAsync(tablet, done);
+
+    TabletNodePtr node;
+    if (!m_tabletnode_manager->FindTabletNode(server_addr, &node)) {
+        LOG(ERROR) << "invalid tablet to load";
+        return;
+    }
+    boost::function<void ()> task_func = 
+        boost::bind(&MasterImpl::LoadTabletAsync, this, tablet, done, 0);
+    ConcurrencyTask task(priority, task_func);
+    node->m_load_spatula.EnQueueTask(task);
+    node->m_load_spatula.TryDrain();
+    LOG(INFO) << "[load] UpdateMetaForLoadCallback " << tablet->GetPath() 
+              << ", at: " << tablet->GetServerAddr();
 }
 
 void MasterImpl::DeleteTableRecordCallback(TablePtr table, int32_t retry_times,
@@ -3852,7 +3863,7 @@ void MasterImpl::ScanMetaCallbackForSplit(TabletPtr tablet,
             LOG(WARNING) << "split not complete, " << tablet;
             tablet->SetStatus(kTableOffLine);
             ProcessOffLineTablet(tablet);
-            TryLoadTablet(tablet);
+            TryLoadTablet(tablet, kTaskLoad);
             delete response;
         } else {
             LOG(ERROR) << kSms << "split into " << record_size << " pieces, "
@@ -3908,9 +3919,9 @@ void MasterImpl::ScanMetaCallbackForSplit(TabletPtr tablet,
     LOG(INFO) << "try load child tablets, \nfirst: " << first_meta.ShortDebugString()
         << "\nsecond: " << second_meta.ShortDebugString();
     ProcessOffLineTablet(first_tablet);
-    TryLoadTablet(first_tablet, server_addr);
+    TryLoadTablet(first_tablet, kTaskLoad, server_addr);
     ProcessOffLineTablet(second_tablet);
-    TryLoadTablet(second_tablet, server_addr);
+    TryLoadTablet(second_tablet, kTaskLoad, server_addr);
     delete response;
 }
 
@@ -3984,7 +3995,7 @@ void MasterImpl::RepairMetaAfterSplitCallback(TabletPtr tablet,
             // we can still repair it at next split
             tablet->SetStatusIf(kTableOffLine, kTableOnSplit);
             ProcessOffLineTablet(tablet);
-            TryLoadTablet(tablet);
+            TryLoadTablet(tablet, kTaskLoad);
         } else {
             WriteClosure* done =
                 NewClosure(this, &MasterImpl::RepairMetaAfterSplitCallback,
@@ -3998,7 +4009,7 @@ void MasterImpl::RepairMetaAfterSplitCallback(TabletPtr tablet,
     delete scan_resp;
     tablet->SetStatusIf(kTableOffLine, kTableOnSplit);
     ProcessOffLineTablet(tablet);
-    TryLoadTablet(tablet);
+    TryLoadTablet(tablet, kTaskLoad);
 }
 
 void MasterImpl::SuspendMetaOperation(TablePtr table, bool is_delete,
@@ -4068,7 +4079,7 @@ void MasterImpl::PushToMetaPendingQueue(MetaTask* task) {
         TabletPtr meta_tablet;
         m_tablet_manager->FindTablet(FLAGS_tera_master_meta_table_name, "",
                                      &meta_tablet);
-        TryMoveTablet(meta_tablet);
+        TryMoveTablet(meta_tablet, kTaskUnload);
     }
 }
 
@@ -4098,7 +4109,7 @@ void MasterImpl::ResumeMetaOperation() {
     m_meta_task_mutex.Unlock();
 }
 
-void MasterImpl::TryMoveTablet(TabletPtr tablet, const std::string& server_addr) {
+void MasterImpl::TryMoveTablet(TabletPtr tablet, int32_t priority, const std::string& server_addr) {
     if (tablet->GetServerAddr() == server_addr) {
         return;
     }
@@ -4114,7 +4125,7 @@ void MasterImpl::TryMoveTablet(TabletPtr tablet, const std::string& server_addr)
         UnloadClosure* done =
             NewClosure(this, &MasterImpl::UnloadTabletCallback, tablet,
                        FLAGS_tera_master_impl_retry_times);
-        UnloadTabletAsync(tablet, done);
+        TryUnloadTablet(tablet, done, priority);
     }
 }
 
@@ -4138,7 +4149,7 @@ void MasterImpl::ProcessReadyTablet(TabletPtr tablet) {
         UnloadClosure* done =
             NewClosure(this, &MasterImpl::UnloadTabletCallback, tablet,
                        FLAGS_tera_master_impl_retry_times);
-        UnloadTabletAsync(tablet, done);
+        TryUnloadTablet(tablet, done, kTaskUnload);
     }
 }
 

--- a/src/master/tabletnode_manager.cc
+++ b/src/master/tabletnode_manager.cc
@@ -11,6 +11,7 @@
 DECLARE_string(tera_master_meta_table_name);
 DECLARE_int32(tera_master_max_load_concurrency);
 DECLARE_int32(tera_master_max_split_concurrency);
+DECLARE_int32(tera_master_max_unload_concurrency);
 DECLARE_int32(tera_master_load_interval);
 DECLARE_double(tera_master_load_balance_size_overload_ratio);
 DECLARE_bool(tera_master_meta_isolate_enabled);
@@ -20,20 +21,25 @@ namespace master {
 
 TabletNode::TabletNode() : m_state(kOffLine),
     m_report_status(kTabletNodeInit), m_data_size(0), m_load(0),
-    m_update_time(0), m_query_fail_count(0), m_onload_count(0),
-    m_onsplit_count(0), m_plan_move_in_count(0) {
+    m_update_time(0), m_query_fail_count(0), m_plan_move_in_count(0),
+    m_load_spatula(FLAGS_tera_master_max_load_concurrency),
+    m_unload_spatula(FLAGS_tera_master_max_unload_concurrency),
+    m_split_spatula(FLAGS_tera_master_max_split_concurrency) {
     m_info.set_addr("");
 }
 
 TabletNode::TabletNode(const std::string& addr, const std::string& uuid)
     : m_addr(addr), m_uuid(uuid), m_state(kOffLine),
       m_report_status(kTabletNodeInit), m_data_size(0), m_load(0),
-      m_update_time(0), m_query_fail_count(0), m_onload_count(0),
-      m_onsplit_count(0), m_plan_move_in_count(0) {
+      m_update_time(0), m_query_fail_count(0), m_plan_move_in_count(0),
+      m_load_spatula(FLAGS_tera_master_max_load_concurrency),
+      m_unload_spatula(FLAGS_tera_master_max_unload_concurrency),
+      m_split_spatula(FLAGS_tera_master_max_split_concurrency) {
     m_info.set_addr(addr);
 }
 
-TabletNode::~TabletNode() {}
+TabletNode::~TabletNode() {
+}
 
 TabletNodeInfo TabletNode::GetInfo() {
     MutexLock lock(&m_mutex);
@@ -96,92 +102,6 @@ bool TabletNode::MayLoadNow() {
         return true;
     }
     return false;
-}
-
-bool TabletNode::TryLoad(TabletPtr tablet) {
-    MutexLock lock(&m_mutex);
-    m_data_size += tablet->GetDataSize();
-    if (m_table_size.find(tablet->GetTableName()) != m_table_size.end()) {
-        m_table_size[tablet->GetTableName()] += tablet->GetDataSize();
-    } else {
-        m_table_size[tablet->GetTableName()] = tablet->GetDataSize();
-    }
-    //VLOG(5) << "load on: " << m_addr << ", size: " << tablet->GetDataSize()
-    //      << ", total size: " << m_data_size;
-    if (m_wait_load_list.empty()
-        && m_onload_count < static_cast<uint32_t>(FLAGS_tera_master_max_load_concurrency)) {
-        BeginLoad();
-        return true;
-    }
-    m_wait_load_list.push_back(tablet);
-    return false;
-}
-
-void TabletNode::BeginLoad() {
-    ++m_onload_count;
-    m_recent_load_time_list.push_back(get_micros());
-    uint32_t list_size = m_recent_load_time_list.size();
-    if (list_size > static_cast<uint32_t>(FLAGS_tera_master_max_load_concurrency)) {
-        CHECK_EQ(list_size - 1, static_cast<uint32_t>(FLAGS_tera_master_max_load_concurrency));
-        m_recent_load_time_list.pop_front();
-    }
-}
-
-bool TabletNode::FinishLoad(TabletPtr tablet) {
-    MutexLock lock(&m_mutex);
-    assert(m_onload_count > 0);
-    --m_onload_count;
-    return true;
-}
-
-bool TabletNode::LoadNextWaitTablet(TabletPtr* tablet) {
-    MutexLock lock(&m_mutex);
-    if (m_onload_count >= static_cast<uint32_t>(FLAGS_tera_master_max_load_concurrency)) {
-        return false;
-    }
-    std::list<TabletPtr>::iterator it = m_wait_load_list.begin();
-    if (it == m_wait_load_list.end()) {
-        return false;
-    }
-    *tablet = *it;
-    m_wait_load_list.pop_front();
-    BeginLoad();
-    return true;
-}
-
-bool TabletNode::TrySplit(TabletPtr tablet) {
-    MutexLock lock(&m_mutex);
-    m_data_size -= tablet->GetDataSize();
-//    VLOG(5) << "split on: " << m_addr << ", size: " << tablet->GetDataSize()
-//        << ", total size: " << m_data_size;
-    if (m_wait_split_list.empty()
-        && m_onsplit_count < static_cast<uint32_t>(FLAGS_tera_master_max_split_concurrency)) {
-        ++m_onsplit_count;
-        return true;
-    }
-    m_wait_split_list.push_back(tablet);
-    return false;
-}
-
-bool TabletNode::FinishSplit(TabletPtr tablet) {
-    MutexLock lock(&m_mutex);
-    --m_onsplit_count;
-    return true;
-}
-
-bool TabletNode::SplitNextWaitTablet(TabletPtr* tablet) {
-    MutexLock lock(&m_mutex);
-    if (m_onsplit_count >= static_cast<uint32_t>(FLAGS_tera_master_max_split_concurrency)) {
-        return false;
-    }
-    std::list<TabletPtr>::iterator it = m_wait_split_list.begin();
-    if (it == m_wait_split_list.end()) {
-        return false;
-    }
-    *tablet = *it;
-    m_wait_split_list.pop_front();
-    ++m_onsplit_count;
-    return true;
 }
 
 NodeState TabletNode::GetState() {
@@ -303,8 +223,9 @@ void TabletNodeManager::UpdateTabletNode(const std::string& addr,
     node->m_table_size = state.m_table_size;
 
     node->m_info.set_status_m(NodeStateToString(node->m_state));
-    node->m_info.set_tablet_onload(node->m_onload_count);
-    node->m_info.set_tablet_onsplit(node->m_onsplit_count);
+    node->m_info.set_tablet_onload(node->m_load_spatula.GetRunningCount());
+    node->m_info.set_tablet_onunload(node->m_unload_spatula.GetRunningCount());
+    node->m_info.set_tablet_onsplit(node->m_split_spatula.GetRunningCount());
     VLOG(15) << "update tabletnode : " << addr;
 }
 

--- a/src/master/tabletnode_manager.cc
+++ b/src/master/tabletnode_manager.cc
@@ -224,7 +224,7 @@ void TabletNodeManager::UpdateTabletNode(const std::string& addr,
 
     node->m_info.set_status_m(NodeStateToString(node->m_state));
     node->m_info.set_tablet_onload(node->m_load_spatula.GetRunningCount());
-    node->m_info.set_tablet_onunload(node->m_unload_spatula.GetRunningCount());
+    node->m_info.set_tablet_unloading(node->m_unload_spatula.GetRunningCount());
     node->m_info.set_tablet_onsplit(node->m_split_spatula.GetRunningCount());
     VLOG(15) << "update tabletnode : " << addr;
 }

--- a/src/master/tabletnode_manager.h
+++ b/src/master/tabletnode_manager.h
@@ -16,6 +16,7 @@
 #include "common/thread_pool.h"
 
 #include "master/tablet_manager.h"
+#include "master/task_spatula.h"
 #include "proto/proto_helper.h"
 
 namespace tera {
@@ -45,11 +46,11 @@ struct TabletNode {
     std::map<std::string, uint64_t> m_table_size;
 
     uint32_t m_query_fail_count;
-    uint32_t m_onload_count;
-    uint32_t m_onsplit_count;
     uint32_t m_plan_move_in_count;
-    std::list<TabletPtr> m_wait_load_list;
-    std::list<TabletPtr> m_wait_split_list;
+    
+    TaskSpatula m_load_spatula;
+    TaskSpatula m_unload_spatula;
+    TaskSpatula m_split_spatula;
 
     // The start time of recent load operation.
     // Used to tell if node load too many tablets within short time.
@@ -72,15 +73,6 @@ struct TabletNode {
 
     // To tell if node load too many tablets within short time.
     bool MayLoadNow();
-
-    bool TryLoad(TabletPtr tablet);
-    void BeginLoad();
-    bool FinishLoad(TabletPtr tablet);
-    bool LoadNextWaitTablet(TabletPtr* tablet);
-
-    bool TrySplit(TabletPtr tablet);
-    bool FinishSplit(TabletPtr tablet);
-    bool SplitNextWaitTablet(TabletPtr* tablet);
 
     NodeState GetState();
     bool SetState(NodeState new_state, NodeState* old_state);

--- a/src/master/task_spatula.cc
+++ b/src/master/task_spatula.cc
@@ -40,8 +40,8 @@ void TaskSpatula::FinishTask() {
     m_running_count--;
 }
 
-void TaskSpatula::TryDrain() {
-    boost::function<void ()> dummy_func = boost::bind(&TaskSpatula::TryDrain, this);
+void TaskSpatula::TryDraining() {
+    boost::function<void ()> dummy_func = boost::bind(&TaskSpatula::TryDraining, this);
     ConcurrencyTask atask(0, dummy_func);
     while(m_running_count < m_max_concurrency
           && DeQueueTask(&atask)) {

--- a/src/master/task_spatula.cc
+++ b/src/master/task_spatula.cc
@@ -1,0 +1,61 @@
+// Copyright (c) 2015, Baidu.com, Inc. All Rights Reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+// Description:  concurrency control with priority for (load/unload/split/merge)
+
+#include "task_spatula.h"
+
+namespace tera {
+namespace master {
+
+TaskSpatula::TaskSpatula(int32_t max)
+    :m_pending_count(0), m_running_count(0), m_max_concurrency(max) {}
+
+TaskSpatula::~TaskSpatula() {
+    assert(m_queue.size() == 0); // TODO copy from ts-a to ts-b, clear m_queue of a
+}
+
+void TaskSpatula::EnQueueTask(const ConcurrencyTask& atask) {
+    MutexLock lock(&m_mutex);
+    m_queue.push(atask);
+    m_pending_count++;
+}
+
+bool TaskSpatula::DeQueueTask(ConcurrencyTask* atask) {
+    MutexLock lock(&m_mutex);
+    assert(atask != NULL);
+    if(m_queue.size() <= 0) {
+        return false;
+    }
+    *atask = m_queue.top();
+    m_queue.pop();
+    m_pending_count--;
+    return true;
+}
+
+void TaskSpatula::FinishTask() {
+    MutexLock lock(&m_mutex);
+    assert(m_running_count > 0);
+    m_running_count--;
+}
+
+void TaskSpatula::TryDrain() {
+    boost::function<void ()> dummy_func = boost::bind(&TaskSpatula::TryDrain, this);
+    ConcurrencyTask atask(0, dummy_func);
+    while(m_running_count < m_max_concurrency
+          && DeQueueTask(&atask)) {
+        atask.async_call();
+        {
+            MutexLock lock(&m_mutex);
+            m_running_count++;
+        }
+    }
+}
+
+int32_t TaskSpatula::GetRunningCount() {
+    return m_running_count;
+}
+
+} // namespace master
+} // namespace tera

--- a/src/master/task_spatula.h
+++ b/src/master/task_spatula.h
@@ -1,0 +1,75 @@
+// Copyright (c) 2015, Baidu.com, Inc. All Rights Reserved
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+// Description:  concurrency control with priority for (load/unload/split/merge)
+
+#ifndef TERA_MASTER_TASK_SPATULA_H_
+#define TERA_MASTER_TASK_SPATULA_H_
+
+#include <boost/bind.hpp>
+#include <boost/function.hpp>
+#include <map>
+#include <queue>
+
+#include "common/mutex.h"
+
+namespace tera {
+namespace master {
+
+// type of item in concurrency control queue
+struct ConcurrencyTask {
+    // great number comes great priority
+    int32_t priority;
+    boost::function<void ()> async_call;
+
+    ConcurrencyTask(int p, boost::function<void ()>& call)
+        : priority(p), async_call(call) {}
+
+    friend bool operator< (ConcurrencyTask t1, ConcurrencyTask t2) {
+        return t1.priority < t2.priority;
+    }
+};
+
+class TaskSpatula {
+public:
+    TaskSpatula(int32_t concurrency_max);
+    ~TaskSpatula();
+
+    // the function adds a item(`task') to concurrency control queue
+    void EnQueueTask(const ConcurrencyTask& task);
+
+    // the function do its best to executes task in concurrency control queue,
+    // until:
+    // 1) reachs the threshold (running count >= concurrency_max), 
+    //    concurrency_max is the parameter of constructor
+    // 2) concurrency control queue has no item anymore
+    void TryDrain();
+
+    // the function minus (count of running task) one
+    // users must call this function when a async task done!
+    void FinishTask();
+
+    // the function return the count of task is running
+    int32_t GetRunningCount();
+
+private:
+    // the function deletes a item (`task') from concurrency control queue
+    // and stores the deleted item at the location given by `task'.
+    //
+    // return value:
+    // if concurrency control queue is empty before deletes, return false;
+    // otherwise, returns true.
+    bool DeQueueTask(ConcurrencyTask* task);
+
+    mutable Mutex m_mutex;
+    std::priority_queue<ConcurrencyTask> m_queue; // concurrency control queue
+    int32_t m_pending_count; // count of task in concurrency control queue
+    int32_t m_running_count; // count of task is running
+    int32_t m_max_concurrency;
+};
+
+} // namespace master
+} // namespace tera
+
+#endif  // TERA_MASTER_TASK_SPATULA_H_

--- a/src/master/task_spatula.h
+++ b/src/master/task_spatula.h
@@ -26,8 +26,8 @@ struct ConcurrencyTask {
     ConcurrencyTask(int p, boost::function<void ()>& call)
         : priority(p), async_call(call) {}
 
-    friend bool operator< (ConcurrencyTask t1, ConcurrencyTask t2) {
-        return t1.priority < t2.priority;
+    bool operator< (const ConcurrencyTask& t) const {
+        return priority < t.priority;
     }
 };
 
@@ -44,7 +44,7 @@ public:
     // 1) reachs the threshold (running count >= concurrency_max), 
     //    concurrency_max is the parameter of constructor
     // 2) concurrency control queue has no item anymore
-    void TryDrain();
+    void TryDraining();
 
     // the function minus (count of running task) one
     // users must call this function when a async task done!

--- a/src/proto/tabletnode.proto
+++ b/src/proto/tabletnode.proto
@@ -53,6 +53,8 @@ message TabletNodeInfo {
     optional uint32 scan_pending = 43;
 
     optional float cpu_usage = 44;
+
+    optional uint32 tablet_onunload = 45;
 }
 
 message LgInheritedLiveFiles {

--- a/src/proto/tabletnode.proto
+++ b/src/proto/tabletnode.proto
@@ -54,7 +54,7 @@ message TabletNodeInfo {
 
     optional float cpu_usage = 44;
 
-    optional uint32 tablet_onunload = 45;
+    optional uint32 tablet_unloading = 45;
 }
 
 message LgInheritedLiveFiles {

--- a/src/tera_flags.cc
+++ b/src/tera_flags.cc
@@ -98,6 +98,7 @@ DEFINE_int64(tera_master_merge_timer_period, 180, "the actived time (in sec) for
 
 DEFINE_int32(tera_master_max_split_concurrency, 1, "the max concurrency of tabletnode for split tablet");
 DEFINE_int32(tera_master_max_load_concurrency, 5, "the max concurrency of tabletnode for load tablet");
+DEFINE_int32(tera_master_max_unload_concurrency, 30, "the max concurrency of tabletnode for unload tablet");
 DEFINE_int32(tera_master_load_interval, 300, "the delay interval (in sec) for load tablet");
 DEFINE_int32(tera_master_load_balance_period, 10000, "the period (in ms) for load balance policy execute");
 DEFINE_bool(tera_master_load_balance_table_grained, true, "whether the load balance policy only consider the specified table");

--- a/src/tera_flags.cc
+++ b/src/tera_flags.cc
@@ -100,7 +100,7 @@ DEFINE_int64(tera_master_merge_timer_period, 180, "the actived time (in sec) for
 
 DEFINE_int32(tera_master_max_split_concurrency, 1, "the max concurrency of tabletnode for split tablet");
 DEFINE_int32(tera_master_max_load_concurrency, 5, "the max concurrency of tabletnode for load tablet");
-DEFINE_int32(tera_master_max_unload_concurrency, 30, "the max concurrency of tabletnode for unload tablet");
+DEFINE_int32(tera_master_max_unload_concurrency, 5, "the max concurrency of tabletnode for unload tablet");
 DEFINE_int32(tera_master_load_interval, 300, "the delay interval (in sec) for load tablet");
 DEFINE_int32(tera_master_load_balance_period, 10000, "the period (in ms) for load balance policy execute");
 DEFINE_bool(tera_master_load_balance_table_grained, true, "whether the load balance policy only consider the specified table");

--- a/src/tera_flags.cc
+++ b/src/tera_flags.cc
@@ -41,6 +41,8 @@ DEFINE_int64(tera_tablet_memtable_ldb_write_buffer_size, 1, "the buffer size(in 
 DEFINE_int64(tera_tablet_memtable_ldb_block_size, 4, "the block size (in KB) for memtable on leveldb");
 DEFINE_int64(tera_tablet_ldb_sst_size, 8, "the sstable file size (in MB) on leveldb");
 
+DEFINE_string(tera_dfs_so_path, "", "the dfs implementation path");
+DEFINE_string(tera_dfs_conf, "", "the dfs configuration file path");
 DEFINE_string(tera_leveldb_env_type, "dfs", "the default type for leveldb IO environment, should be [local | dfs]");
 DEFINE_string(tera_leveldb_env_dfs_type, "hdfs", "the default type for leveldb IO dfs environment, [hdfs | nfs]");
 DEFINE_string(tera_leveldb_env_hdfs2_nameservice_list, "default", "the nameservice list of hdfs2");


### PR DESCRIPTION
并发控制：防止过多的ts操作（例如unload）一次性发送到ts，压垮低层dfs.
pending队列中不再是简单的tablet，而是用boost::bind打包好的task.
task包括2个成员：这个task的优先级，以及要执行的调用。

