### PR TITLE
add more git info to build_version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,9 @@ TABLETNODE_SRC := $(wildcard src/tabletnode/*.cc)
 IO_SRC := $(wildcard src/io/*.cc)
 SDK_SRC := $(wildcard src/sdk/*.cc)
 PROTO_SRC := $(filter-out %.pb.cc, $(wildcard src/proto/*.cc)) $(PROTO_OUT_CC)
-OTHER_SRC := $(wildcard src/zk/*.cc) $(wildcard src/utils/*.cc) src/tera_flags.cc \
-            src/version.cc
+VERSION_SRC := src/version.cc
+OTHER_SRC := $(wildcard src/zk/*.cc) $(wildcard src/utils/*.cc) $(VERSION_SRC) \
+	         src/tera_flags.cc
 COMMON_SRC := $(wildcard src/common/base/*.cc) $(wildcard src/common/net/*.cc) \
               $(wildcard src/common/file/*.cc) $(wildcard src/common/file/recordio/*.cc)
 SERVER_SRC := src/tera_main.cc src/tera_entry.cc
@@ -72,7 +73,7 @@ cleanall:
 	$(MAKE) clean
 	rm -rf build
 
-tera_main: version $(SERVER_OBJ) $(LEVELDB_LIB) $(MASTER_OBJ) $(TABLETNODE_OBJ) \
+tera_main: $(SERVER_OBJ) $(LEVELDB_LIB) $(MASTER_OBJ) $(TABLETNODE_OBJ) \
            $(IO_OBJ) $(SDK_OBJ) $(PROTO_OBJ) $(OTHER_OBJ) $(COMMON_OBJ)
 	$(CXX) -o $@ $(SERVER_OBJ) $(MASTER_OBJ) $(TABLETNODE_OBJ) $(IO_OBJ) $(SDK_OBJ) \
 	$(PROTO_OBJ) $(OTHER_OBJ) $(COMMON_OBJ) $(LDFLAGS)
@@ -89,6 +90,9 @@ src/leveldb/libleveldb.a:
 $(ALL_OBJ): %.o: %.cc $(PROTO_OUT_H)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
+$(VERSION_SRC): build_version.sh
+	sh build_version.sh
+
 .PHONY: proto
 proto: $(PROTO_OUT_CC) $(PROTO_OUT_H)
  
@@ -96,8 +100,3 @@ proto: $(PROTO_OUT_CC) $(PROTO_OUT_H)
 	$(PROTOC) --proto_path=./src/proto/ --proto_path=$(PROTOBUF_INCDIR) \
                   --proto_path=$(SOFA_PBRPC_INCDIR) \
                   --cpp_out=./src/proto/ $< 
-
-.PHONY: version
-src/version.cc version:
-	sh build_version.sh
-

--- a/build_version.sh
+++ b/build_version.sh
@@ -44,6 +44,7 @@ VERSION_CPP_FILE=src/version.cc
 
 # generate template file
 git remote -v | sed 's/$/&\\n\\/g' > $GIT_INFO_FILE
+git log | head -n 3 | sed 's/$/&\\n\\/g' >> $GIT_INFO_FILE
 gen_info_template_header > $TEMPLATE_HEADER_FILE
 gen_info_template_foot > $TEMPLATE_FOOT_FILE
 gen_info_print_template >> $TEMPLATE_FOOT_FILE


### PR DESCRIPTION
在tera_main中添加更多的git信息
实际场景中，目前的tera_main提供的信息较少，有时候容易混淆各个不同版本的二进制。

1. 添加添加最近commit的hash值、作者、时间

2. 修复Makefile中的一个bug：原Makefile有这么一句 `tera_main: version .....  $(OTHER_OBJ)`
tera_main同时依赖`version`和`OTHER_OBJ`。

`version`负责根据build_version.sh生成version.cc.
`OTHER_OBJ`规则根据version.cc生成`version.o`，

如果多线程编译(`make -j32`)，观察到的情况：make判断version.o是否需要更新时，version.cc还未来得及更新，导致version.o是旧版本的信息。

bug复现方法：
1. 修改build_version.sh，在tera_main中添加更多版本的信息，例如在第46行下新增一行`echo "hello, make" | sed 's/$/&\\n\\/g' >> $GIT_INFO_FILE`
2. make -j32
3. ./tera_main version  # 应该还是旧的version信息，添加"hello, make"失败